### PR TITLE
remove command option!(R::PolyRing)

### DIFF
--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -52,14 +52,6 @@ function rBitmask(r::ring)
    icxx"""(unsigned int)$r->bitmask;"""
 end
 
-function rSetOption_redSB(r::ring)
-   icxx"""$r->options |= Sy_bit(OPT_REDSB);"""
-end
-
-function rSetOption_redTail(r::ring)
-   icxx"""$r->options |= Sy_bit(OPT_REDTAIL);"""
-end
-
 function p_Delete(p::poly, r::ring)
    icxx"""p_Delete(&$p, $r);"""
 end

--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -53,19 +53,11 @@ function rBitmask(r::ring)
 end
 
 function rSetOption_redSB(r::ring)
-   icxx"""const ring origin = currRing;
-          rChangeCurrRing($r);
-          si_opt_1 |= Sy_bit(OPT_REDSB);
-          rChangeCurrRing(origin);
-       """
+   icxx"""$r->options |= Sy_bit(OPT_REDSB);"""
 end
 
 function rSetOption_redTail(r::ring)
-   icxx"""const ring origin = currRing;
-          rChangeCurrRing($r);
-          si_opt_1 |= Sy_bit(OPT_REDTAIL);
-          rChangeCurrRing(origin);
-       """
+   icxx"""$r->options |= Sy_bit(OPT_REDTAIL);"""
 end
 
 function p_Delete(p::poly, r::ring)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1,6 +1,5 @@
 export spoly, PolyRing, coeff, coeffs_expos, degree, exponent!, isgen, content,
-       exponent, lead_exponent, ngens, degree_bound, option!, primpart,
-       @PolynomialRing
+       exponent, lead_exponent, ngens, degree_bound, primpart, @PolynomialRing
 
 ###############################################################################
 #
@@ -29,17 +28,6 @@ end
 
 function degree_bound(R::PolyRing)
    return Int(libSingular.rBitmask(R.ptr))
-end
-
-function option!(r::PolyRing, opt::Symbol)
-   if opt == :redSB
-      libSingular.rSetOption_redSB(r.ptr)
-   elseif opt == :redTail
-      libSingular.rSetOption_redTail(r.ptr)
-   else
-      error("option " * string(opt) * " not recognized")
-   end
-   r
 end
 
 zero(R::PolyRing) = R()


### PR DESCRIPTION
There is already an optional argument complete_reduction for std() which is a much better approach than setting ring dependent options as in Singular.