### PR TITLE
add 'using Hecke' in LibSingular.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.5
+Cxx
 Nemo
+Hecke

--- a/src/LibSingular.jl
+++ b/src/LibSingular.jl
@@ -4,6 +4,8 @@ using Cxx
 
 using Nemo
 
+using Hecke
+
 import Base:setindex!, getindex
 
 include("libsingular/LibSingularTypes.jl")


### PR DESCRIPTION
nemoRingExtGcd() from libsingular/nemo/Rings.jl calls Hecke for
gcdx(n1, n2) if n1 and n2 are of type Nemo.nmod.