### PR TITLE
the `show` function must print everything to the same `io`

### DIFF
--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -48,7 +48,7 @@ end
 function show(io::IO, I::smodule)
    print(io, "Singular Module over ")
    show(io, base_ring(I))
-   println(", with Generators:")
+   println(io, ", with Generators:")
    n = ngens(I)
    for i = 1:n
       show(io, I[i])


### PR DESCRIPTION
I noticed the problem because the interface from GAP to Julia can access only what is printed to the `io`,
not what is printed to the screen.
In other situations, the bug would be difficult to spot.