### PR TITLE
Convert singular polynomials to AbstractAlgebra polynomials

### DIFF
--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -197,5 +197,37 @@ p = primpart(f)
 c = content(f)
 ```
 
+### Conversion between Singular.jl polynomials and MPoly polynomials
 
+There are conversion functions between the polynomial ring implementation
+from Singular.jl and the generic MPoly implementation from AbstractAlgebra.jl.
 
+```@docs
+AsEquivalentSingularPolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
+      ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
+      degree_bound::Int = 0)  where {T <: RingElem}
+```
+
+```@docs
+AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: Nemo.RingElem}
+```
+
+**Examples**
+
+Conversion of generic AbstractAlgebra polynomials to Singular.jl polynomials:
+
+```
+K = Nemo.ZZ
+R,(x,y) = AbstractAlgebra.Generic.PolynomialRing(K, ["x","y"]);
+Rsing,vars_Rsing = Singular.AsEquivalentSingularPolynomialRing(R);
+Rsing(x+y) == Rsing(x) + Rsing(y)
+```
+
+Conversion of Singular.jl polynomials to generic AbstractAlgebra polynomials:
+
+```
+K = Nemo.ZZ
+S,(u,v) = Singular.PolynomialRing(K, ["u","v"])
+Saa,(uu,vv) = Singular.AsEquivalentAbstractAlgebraPolynomialRing(S)
+Saa(u) + Saa(v) == Saa(u) + Saa(v)
+```

--- a/src/number/n_unknown.jl
+++ b/src/number/n_unknown.jl
@@ -190,10 +190,6 @@ promote_rule{S <: Nemo.RingElem}(::Type{n_unknown{S}}, ::Type{Nemo.fmpz}) = n_un
 
 promote_rule{S <: Nemo.FieldElem}(::Type{n_unknown{S}}, ::Type{Nemo.fmpq}) = n_unknown{S}
 
-function convert( ::Type{T}, a::Singular.n_unknown{T} ) where {T <: Nemo.RingElem}
-   return unsafe_load( reinterpret( Ptr{elem_type(parent(a).base_ring )}, a.ptr ) )
-end
-
 ###############################################################################
 #
 #   Parent call overloads

--- a/src/number/n_unknown.jl
+++ b/src/number/n_unknown.jl
@@ -190,6 +190,10 @@ promote_rule{S <: Nemo.RingElem}(::Type{n_unknown{S}}, ::Type{Nemo.fmpz}) = n_un
 
 promote_rule{S <: Nemo.FieldElem}(::Type{n_unknown{S}}, ::Type{Nemo.fmpq}) = n_unknown{S}
 
+function convert( ::Type{T}, a::Singular.n_unknown{T} ) where {T <: Nemo.RingElem}
+   return unsafe_load( reinterpret( Ptr{elem_type(parent(a).base_ring )}, a.ptr ) )
+end
+
 ###############################################################################
 #
 #   Parent call overloads

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -660,7 +660,7 @@ function (R::AbstractAlgebra.Generic.MPolyRing{T}){T <: Nemo.RingElem}(p::Singul
    t = start(iterator)
    while !done(iterator,t)
       (coeff,exps),t = next(iterator,t)
-      new_p = new_p + convert(T,coeff) * prod(gens.^exps)
+      new_p = new_p + libSingular.julia(coeff.ptr) * prod(gens.^exps)
    end
    return(new_p)
 end

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -607,19 +607,29 @@ end
 #
 ###############################################################################
 
+doc"""
+    AsEquivalentSingularPolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
+      ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
+      degree_bound::Int = 0)  where {T <: RingElem}
+> Return a Singular (multivariate) polynomial ring over the base ring of $R$ in variables having the same names as those of R.
+"""
 function AsEquivalentSingularPolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
       ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
-      degree_bound::Int = 0)  where {T <: RingElement}
+      degree_bound::Int = 0)  where {T <: RingElem}
    return PolynomialRing(AbstractAlgebra.Generic.base_ring(R), [string(v) for v in AbstractAlgebra.Generic.symbols(R)], cached=cached, ordering=ordering, ordering2=ordering2, degree_bound=degree_bound)
 end
 
-function AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: Nemo.RingElem}
+doc"""
+    AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: RingElem}
+> Return an AbstractAlgebra (multivariate) polynomial ring over the base ring of $R$ in variables having the same names as those of R.
+"""
+function AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: RingElem}
    return AbstractAlgebra.Generic.PolynomialRing(base_ring(R).base_ring, Base.convert( Array{String,1}, symbols(R)), ordering=ordering)
 end
 
 
 doc"""
-   (R::PolyRing){T <: Nemo.RingElem}(p::AbstractAlgebra.Generic.MPoly{T})
+    (R::PolyRing){T <: RingElem}(p::AbstractAlgebra.Generic.MPoly{T})
 > Return a Singular polynomial in $R$ with the same coefficients and exponents as $p$.
 """
 function (R::PolyRing){T <: Nemo.RingElem}(p::AbstractAlgebra.Generic.MPoly{T})

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -581,12 +581,6 @@ function PolynomialRing(R::Nemo.Ring, s::Array{String, 1}; cached::Bool = true,
    return tuple(parent_obj, gens(parent_obj))
 end
 
-function PolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
-      ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
-      degree_bound::Int = 0)  where {T <: RingElement}
-   return PolynomialRing(AbstractAlgebra.Generic.base_ring(R), [string(v) for v in vars(R)], cached=cached, ordering=ordering, ordering2=ordering2, degree_bound=degree_bound)
-end
-
 macro PolynomialRing(R, s, n, o)
    S = gensym()
    y = gensym()
@@ -606,6 +600,23 @@ macro PolynomialRing(R, s, n)
    v1 = Expr(:block, exp1, v..., S)
    return esc(v1)
 end
+
+###############################################################################
+#
+#   Conversion functions
+#
+###############################################################################
+
+function AsEquivalentSingularPolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
+      ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
+      degree_bound::Int = 0)  where {T <: RingElement}
+   return PolynomialRing(AbstractAlgebra.Generic.base_ring(R), [string(v) for v in vars(R)], cached=cached, ordering=ordering, ordering2=ordering2, degree_bound=degree_bound)
+end
+
+function AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: Nemo.RingElem}
+   return AbstractAlgebra.Generic.PolynomialRing(base_ring(R).base_ring, Base.convert( Array{String,1}, symbols(R)), ordering=ordering)
+end
+
 
 doc"""
    (R::PolyRing){T <: Nemo.RingElem}(p::AbstractAlgebra.Generic.MPoly{T})
@@ -632,6 +643,24 @@ function (R::PolyRing){T <: Nemo.RingElem}(p::AbstractAlgebra.Generic.MPoly{T})
          prod = prod * gens(R)[j]^Int(exps[j,i])
       end
       new_p = new_p + prod
+   end
+   return(new_p)
+end
+
+doc"""
+   (R::AbstractAlgebra.Generic.MPolyRing{T}){T <: Nemo.RingElem}(p::Singular.spoly{Singular.n_unknown{T}})
+> Return a AbstractAlgebra polynomial in R with the same coefficients and exponents as $p$.
+"""
+function (R::AbstractAlgebra.Generic.MPolyRing{T}){T <: Nemo.RingElem}(p::Singular.spoly{Singular.n_unknown{T}})
+   parent_ring = parent(p)
+   n = ngens(parent_ring)
+   new_p = zero(R)
+   gens = AbstractAlgebra.Generic.gens(R)
+   iterator = coeffs_expos(p)
+   t = start(iterator)
+   while !done(iterator,t)
+      (coeff,exps),t = next(iterator,t)
+      new_p = new_p + convert(T,coeff) * prod(gens.^exps)
    end
    return(new_p)
 end

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -610,7 +610,7 @@ end
 function AsEquivalentSingularPolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true,
       ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
       degree_bound::Int = 0)  where {T <: RingElement}
-   return PolynomialRing(AbstractAlgebra.Generic.base_ring(R), [string(v) for v in vars(R)], cached=cached, ordering=ordering, ordering2=ordering2, degree_bound=degree_bound)
+   return PolynomialRing(AbstractAlgebra.Generic.base_ring(R), [string(v) for v in AbstractAlgebra.Generic.symbols(R)], cached=cached, ordering=ordering, ordering2=ordering2, degree_bound=degree_bound)
 end
 
 function AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: Nemo.RingElem}

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -255,21 +255,32 @@ function test_spoly_Polynomials()
    println("PASS")
 end
 
-function test_convert_MPoly_to_SingularPoly()
+function test_convert_between_MPoly_and_SingularPoly()
    print("spoly.test_convert_MPoly_to_SingularPoly...")
-   for num_vars=1:10
+   for num_vars=2:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = AbstractAlgebra.rand_ordering()
 
       R, vars_R = AbstractAlgebra.Generic.PolynomialRing(Nemo.ZZ, var_names; ordering=ord)
-      Rsing, vars_Rsing = Singular.PolynomialRing(R)
+      Rsing, vars_Rsing = Singular.AsEquivalentSingularPolynomialRing(R)
       for iter in 1:10
          f = AbstractAlgebra.Generic.rand(R, 5:10, 1:10, -100:100)
          g = AbstractAlgebra.Generic.rand(R, 5:10, 1:10, -100:100)
          @test Rsing(f * g) == Rsing(f) * Rsing(g)
          @test Rsing(f + g) == Rsing(f) + Rsing(g)
          @test Rsing(f - g) == Rsing(f) - Rsing(g)
+         @test R(Rsing(f)) == f
       end
+
+      S, vars_S = Singular.PolynomialRing(Nemo.ZZ, var_names; ordering=ord)
+      SAA, vars_SAA = Singular.AsEquivalentAbstractAlgebraPolynomialRing(S)
+      # FIXME: Better generate random polynomials
+      f = 1+vars_S[1]*vars_S[2]
+      g = vars_S[1]^2 + vars_S[2]^3
+      @test SAA(f * g) == SAA(f) * SAA(g)
+      @test SAA(f + g) == SAA(f) + SAA(g)
+      @test SAA(f - g) == SAA(f) - SAA(g)
+      @test S(SAA(f)) == f
    end
 end
 
@@ -285,7 +296,7 @@ function test_spoly()
    test_spoly_gcd_lcm()
    test_spoly_extended_gcd()
    test_spoly_Polynomials()
-   test_convert_MPoly_to_SingularPoly()
+   test_convert_between_MPoly_and_SingularPoly()
 
    println("")
 end


### PR DESCRIPTION
These functions allow converting singular polynomial rings and polynomials to polynomial rings and polynomials in AbstractAlgebra.

The name of the existing function

    PolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true, ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min, degree_bound::Int = 0)  where {T <: RingElement}

was changed to

    AsEquivalentSingularPolynomialRing

The "converse" is the function

    function AsEquivalentAbstractAlgebraPolynomialRing(R::Singular.PolyRing{Singular.n_unknown{T}}; ordering::Symbol = :degrevlex)  where {T <: Nemo.RingElem}

Note however that after

```
using Cxx;
using Singular;
K = Nemo.ArbField(64);
R,vars_R = AbstractAlgebra.Generic.PolynomialRing(K, ["x","y"]);
RR,vars_RR = Singular.AsEquivalentSingularPolynomialRing(R);
RRR,vars_RRR = Singular.AsEquivalentAbstractAlgebraPolynomialRing(RR)
```

the output of 

`RRR == R`

is `false`, as a new ring is constructed. In my opinion this is the desired behavior.