### PR TITLE
Fix for OS X compatibility

### DIFF
--- a/src/LibSingular.jl
+++ b/src/LibSingular.jl
@@ -1,7 +1,8 @@
 module libSingular
 
+import Libdl
 using CxxWrap
-@wrapmodule(realpath(joinpath(@__DIR__, "..", "local", "lib", "libsingularwrap.so")))
+@wrapmodule(realpath(joinpath(@__DIR__, "..", "local", "lib", "libsingularwrap." * Libdl.dlext)))
 
 function __init__()
    @initcxx


### PR DESCRIPTION
On OS X, shared library have extension `.dylib`, no `.so` (and on Windows `.dll`, but I don't claim that this works on Windows ;-).