### PR TITLE
Switch to NTL 10.5.0

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ cd(wdir)
 
 # INSTALL NTL
 
-const ntl="ntl-9.3.0"
+const ntl="ntl-10.5.0"
 
 try
   run(`wget -q -nc -c -O "$wdir/$ntl.tar.gz" "http://www.shoup.net/ntl/$ntl.tar.gz"`)


### PR DESCRIPTION
Fixes #45 

This seems to work fine for me. Of course, by now there is NTL 11.3.1, but I thought it's best to not upgrade to quickly, so I took the last release from the 10.x branch.