### PR TITLE
WIP: some Travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
-sudo: false
+# Force Ubuntu 16.04 "Xenial" to get newer GCC, binutils etc.
+dist: xenial
+
+language: julia
+julia: 1.0
+
 addons:
     apt:
-        sources:
-           - ubuntu-toolchain-r-test
-           - george-edison55-precise-backports
+        #sources:
+        #   - ubuntu-toolchain-r-test
+        #   - george-edison55-precise-backports
         packages:
            - cmake
            - cmake-data
-           - gcc-6
-           - g++-6
-           - binutils
+           #- gcc-6
+           #- g++-6
+           #- binutils
            - gfortran
            - libblas-dev
            - liblapack-dev
@@ -18,35 +23,14 @@ addons:
  
 matrix:
     include:
-       - language: julia
-         julia: 1.0
-         os: linux
-       - language: julia
-         julia: 1.0
-         os: osx
+       - os: linux
+       - os: osx
+
 install:
+    #- if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-6" CC="gcc-6"; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CXX="clang++" CC="clang"; fi
     - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH="$HOME/usr/bin:$PATH"; fi
     - export THE_PKG_DIR=`julia -e 'println(Pkg.dir())'`
 
-script:
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -f $HOME/usr/bin/ld ]; then
-         wget https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz;
-         tar xzf binutils-2.27.tar.gz;
-         (cd binutils-2.27 && ./configure --prefix=$HOME/usr && make && make install);
-      fi;
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'using Pkg; Pkg.clone("https://github.com/oscar-system/Singular.jl")' || false; fi
-    - while sleep 30; do echo "still alive"; done &
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'Pkg.build("Singular")' || false; fi
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'Pkg.test("Singular"; coverage=true)' || false; fi
-
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Singular"); Pkg.test("Singular"; coverage=true)'
-after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ cd(wdir)
 
 # INSTALL NTL
 
-const ntl="ntl-9.3.0"
+const ntl="ntl-10.5.0"
 
 try
   run(`wget -q -nc -c -O "$wdir/$ntl.tar.gz" "http://www.shoup.net/ntl/$ntl.tar.gz"`)


### PR DESCRIPTION
- switch to Ubuntu 16.04 "xenial" base image
- this has newer binutils 2.26, so perhaps those are new enough? If not, then instead of 2.27, why not go to something even newer?
- rely on default scripts to do coverage reporting 
- this means that the `- while sleep 30; do echo "still alive"; done &` is gone, which probably then needs to be added back *sigh*, but I'll look into that later, if I have more time