### PR TITLE
Fix OS X linker issue and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,9 @@ julia: 1.0
 
 addons:
     apt:
-        #sources:
-        #   - ubuntu-toolchain-r-test
-        #   - george-edison55-precise-backports
         packages:
            - cmake
            - cmake-data
-           #- gcc-6
-           #- g++-6
-           #- binutils
            - gfortran
            - libblas-dev
            - liblapack-dev
@@ -26,29 +20,17 @@ matrix:
        - os: linux
        - os: osx
 
-install:
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CXX="clang++" CC="clang"; fi
-    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH="$HOME/usr/bin:$PATH"; fi
-    - export THE_PKG_DIR=`julia -e 'println(Pkg.dir())'`
-
 script:
-    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -f $HOME/usr/bin/ld ]; then
-         wget https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz;
-         tar xzf binutils-2.27.tar.gz;
-         (cd binutils-2.27 && ./configure --prefix=$HOME/usr && make && make install);
-      fi;
     - while sleep 30; do echo "still alive"; done &
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'using Pkg; pkg"add https://github.com/oscar-system/Singular.jl"' || false; fi
-    - if [ ! -f $HOME/early_abort ]; then julia -e 'using Pkg; Pkg.test("Singular"; coverage=true)' || false; fi
+    - git fetch --unshallow
+    - julia --color=yes -e  'using Pkg; Pkg.clone(pwd()); Pkg.build("Singular")'
+    - julia --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test("Singular"; coverage=true)'
 
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Singular"); Pkg.test("Singular"; coverage=true)'
+
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'using Pkg; cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia --color=yes -e 'using Pkg; cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia --color=yes -e 'using Pkg; cd(Pkg.dir("Singular")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -103,6 +103,8 @@ withenv("CPP_FLAGS"=>"-I$vdir/include", "LD_LIBRARY_PATH"=>"$vdir/lib:$nemodir/l
    end
 end
 
+print("Done building Singular")
+
 cd(wdir)
 
 push!(Libdl.DL_LOAD_PATH, "$pkgdir/local/lib")
@@ -119,8 +121,12 @@ cmake_build_path = joinpath(@__DIR__, "src")
 
 cd(cmake_build_path)
 
+print("Initializing cmake")
+
 run(`cmake -DJulia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -DJuliaIncludeDir=$julia_include -DJULIA_LIB_DIR=$julia_lib -Dnemo_includes=$nemovdir/include -Dsingular_includes=$vdir/include -Dsingular_libdir=$vdir/lib -DCMAKE_INSTALL_LIBDIR=$vdir/lib .`)
 
-run(`make`)
+print("Running cmake")
+
+run(`make VERBOSE=1`)
 run(`make install`)
 

--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -14,7 +14,7 @@ SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" )
 SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -L${JULIA_LIB_DIR} -Wl,-rpath,${JULIA_LIB_DIR} -L${singular_libdir} -Wl,-rpath,${singular_libdir}" )
 
 add_library(singularwrap SHARED singular.cpp rings.cpp coeffs.cpp ideals.cpp matrices.cpp)
-target_link_libraries(singularwrap JlCxx::cxxwrap_julia -ljulia "-lSingular -ldl")
+target_link_libraries(singularwrap JlCxx::cxxwrap_julia -ljulia "-lSingular -lpolys -lfactory -lomalloc -ldl")
 
 install(TARGETS
   singularwrap


### PR DESCRIPTION
This fixes linking on OS X, by adding the required linker flags for all sub-libraries to the linker command in the `CMakeList.txt` (nb, to me this looks like a bug in the Singular build system; or, well, at the very least `libsingular-config` should report the correct flags, but it doesn't seem to, and moreover, at least over here the `libsingular-config` that is being generated is not executable... but that's all issues for Singular to resolve, no Singular.jl). BTW, I left out the `-lsingular_resources` as it does not seem to be needed.

Then, I cleaned up .travis.yml to actually build the Singular.jl in the branch being tested -- the current build script *always* compiles and tests the `master` branch of the https://github.com/oscar-system/Singular.jl/ repository, so it doesn't work for pull requests and forks (and that's why the linker fix did not work for you @wbhart -- it kept building the version in oscar-system/Singular.jl, not in wbhart/Singular.jl).

Finally, I make the build process slightly more verbose to help debugging.