### PR TITLE
README.md: fix Travis/Codecov/Coveralls URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Singular
 
-[![Build Status](https://travis-ci.org/wbhart/Singular.jl.svg?branch=master)](https://travis-ci.org/wbhart/Singular.jl)
+[![Build Status](https://travis-ci.com/oscar-system/Singular.jl.svg?branch=master)](https://travis-ci.com/oscar-system/Singular.jl)
 
-[![Coverage Status](https://coveralls.io/repos/wbhart/Singular.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/wbhart/Singular.jl?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/oscar-system/Singular.jl/badge.svg)](https://coveralls.io/github/oscar-system/Singular.jl)
 
-[![codecov.io](http://codecov.io/github/wbhart/Singular.jl/coverage.svg?branch=master)](http://codecov.io/github/wbhart/Singular.jl?branch=master)
+[![codecov.io](https://codecov.io/github/oscar-system/Singular.jl/coverage.svg?branch=master)](https://codecov.io/gh/oscar-system/Singular.jl)
 
 Julia package for using the [Singular](https://www.singular.uni-kl.de/) library for commutative and
 non-commutative algebra, algebraic geometry, and singularity theory.


### PR DESCRIPTION
I also enabled coveralls for this repo, fixed the codecov integration, and removed the outdated travis.org "GitHub Service" integration (leaving the travis.com "GitHub Apps" integration in place -- now Travis won't have to build every PR and commit twice ;-). 