### PR TITLE
use Documenter.HTML() instead of :html

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, Singular
 
 makedocs(
-         format   = :html,
+         format   = Documenter.HTML(),
          sitename = "Singular.jl",
          pages    = [
              "index.md",


### PR DESCRIPTION
This addresses the following warning:

    Warning: `format = :html` is deprecated, use `format = Documenter.HTML()` instead.
