### PR TITLE
Switch to using iterators for coeffs, exponent vectors, monomials and terms and add build contexts

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 1.0
-AbstractAlgebra
+AbstractAlgebra 0.3.3
 Nemo
 CxxWrap

--- a/deps/src/rings.cpp
+++ b/deps/src/rings.cpp
@@ -95,6 +95,10 @@ void singular_define_rings(jlcxx::Module & Singular)
         poly p = pNext(a);
         return p;
     });
+    Singular.method("p_Head", [](spolyrec * a, ip_sring * r) {
+        poly p = p_Head(a, r); return p; });
+    Singular.method("p_SetCoeff0", [](spolyrec * a, snumber * n, ip_sring * r) {
+        p_SetCoeff0(a, n, r); });
     Singular.method("p_Neg",
                     [](spolyrec * p, ip_sring * r) { return p_Neg(p, r); });
     Singular.method("pGetCoeff", [](spolyrec * p) { return pGetCoeff(p); });

--- a/deps/src/rings.cpp
+++ b/deps/src/rings.cpp
@@ -105,6 +105,8 @@ void singular_define_rings(jlcxx::Module & Singular)
         pNext(a) = m; });
     Singular.method("p_SortMerge", [](spolyrec * a, ip_sring * r) {
         return p_SortMerge(a, r); });
+    Singular.method("p_SortAdd", [](spolyrec * a, ip_sring * r) {
+        return p_SortAdd(a, r); });
     Singular.method("p_Neg",
                     [](spolyrec * p, ip_sring * r) { return p_Neg(p, r); });
     Singular.method("pGetCoeff", [](spolyrec * p) { return pGetCoeff(p); });

--- a/deps/src/rings.cpp
+++ b/deps/src/rings.cpp
@@ -70,7 +70,6 @@ void singular_define_rings(jlcxx::Module & Singular)
     Singular.method("p_IsOne",
                     [](spolyrec * p, ip_sring * r) { return p_IsOne(p, r); });
     Singular.method("p_One", [](ip_sring * r) { return p_One(r); });
-    Singular.method("p_Init", [](ip_sring * r) { return p_Init(r); });
     Singular.method("p_IsUnit", [](spolyrec * p, ip_sring * r) {
         return p_IsUnit(p, r);
     });
@@ -95,10 +94,17 @@ void singular_define_rings(jlcxx::Module & Singular)
         poly p = pNext(a);
         return p;
     });
+    Singular.method("p_Init", [](ip_sring * r) { return p_Init(r); });
     Singular.method("p_Head", [](spolyrec * a, ip_sring * r) {
         poly p = p_Head(a, r); return p; });
     Singular.method("p_SetCoeff0", [](spolyrec * a, snumber * n, ip_sring * r) {
         p_SetCoeff0(a, n, r); });
+    Singular.method("p_SetExp", [](spolyrec * a, int i, int v, ip_sring * r) {
+        p_SetExp(a, i, v, r); });
+    Singular.method("p_SetNext", [](spolyrec * a, spolyrec * m) {
+        pNext(a) = m; });
+    Singular.method("p_SortMerge", [](spolyrec * a, ip_sring * r) {
+        return p_SortMerge(a, r); });
     Singular.method("p_Neg",
                     [](spolyrec * p, ip_sring * r) { return p_Neg(p, r); });
     Singular.method("pGetCoeff", [](spolyrec * p) { return pGetCoeff(p); });

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -13,7 +13,7 @@ The associated polynomial ring is represented by a parent object which can be
 constructed by a call to the `PolynomialRing` constructor.
 
 The types of the polynomial ring parent objects and elements thereof are given in the
-following table according to the library provding them.
+following table according to the library providing them.
 
  Library        | Element type  | Parent type
 ----------------|---------------|-----------------------
@@ -22,8 +22,8 @@ Singular        | `spoly{T}`    | `Singular.PolyRing{T}`
 These types are parameterised by the type of elements in the coefficient ring of the
 polynomials.
 
-All polynomial types belong directly to the abstract type `RingElem` and
-all the polynomial ring parent object types belong to the abstract type `Ring`.
+All polynomial types belong directly to the abstract type `MPolyElem` and
+all the polynomial ring parent object types belong to the abstract type `MPolyRing`.
 
 ## Multivariate polynomial functionality
 
@@ -99,6 +99,26 @@ polynomial ring of type AbstractAlgebra.Generic.MPolyRing:
 
 ```@docs
 PolynomialRing(R::AbstractAlgebra.Generic.MPolyRing{T}; cached::Bool = true, ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min, degree_bound::Int = 0)  where {T <: RingElement}
+```
+
+Polynomials can be constructed using arithmetic operations on the generators,
+but this can be extremely inefficient. For this purpose, Singular polynomials
+support construction using a build context, as described in the AbstractAlgebra
+documentation:
+
+[https://nemocas.github.io/AbstractAlgebra.jl/mpolynomial_rings.html](https://nemocas.git
+hub.io/AbstractAlgebra.jl/mpolynomial_rings.html)
+
+**Examples**
+
+```julia
+R, (x, y) = PolynomialRing(ZZ, ["x", "y"])
+C = MPolyBuildCtx(R)
+
+push_term!(C, ZZ(1), [1, 2])
+push_term!(C, ZZ(3), [1, 1])
+push_term!(C, -ZZ(1), [0, 1])
+f = finish(C)
 ```
 
 ### Polynomial ring macros

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -18,11 +18,12 @@ import Statistics: std
 import Nemo: add!, addeq!, base_ring, canonical_unit,
              characteristic, check_parent, coeff,
              coeffs, contains, content, crt, degree, divexact,
-             elem_type, exponent_vectors, gcdinv,
+             elem_type, exponent_vectors, finish, gcdinv,
              gens, intersect, isconstant, isnegative, isone,
              isgen, iszero, isunit, lead, monomials,
-             mul!, needs_parentheses, parent_type,
-             parent, primpart, promote_rule, reconstruct, show_minus_one,
+             MPolyBuildCtx, mul!, needs_parentheses, nvars, parent_type,
+             parent, primpart, promote_rule, push_term!,
+             reconstruct, show_minus_one, sort_terms!,
              terms, zero!, ResidueRing
 
 export base_ring, elem_type, parent_type, parent

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -15,12 +15,15 @@ import LinearAlgebra: normalize!, rank
 
 import Statistics: std
 
-import Nemo: add!, addeq!, base_ring, canonical_unit, check_parent, coeff,
-             contains, content, crt, divexact,
-             elem_type, gcdinv, gens, isnegative, isone,
-             isgen, iszero, isunit, lead, mul!, needs_parentheses, parent_type,
-             parent, primpart, promote_rule, reconstruct, show_minus_one, zero!,
-             ResidueRing, characteristic, degree, intersect, isconstant
+import Nemo: add!, addeq!, base_ring, canonical_unit,
+             characteristic, check_parent, coeff,
+             coeffs, contains, content, crt, degree, divexact,
+             elem_type, exponent_vectors, gcdinv,
+             gens, intersect, isconstant, isnegative, isone,
+             isgen, iszero, isunit, lead, monomials,
+             mul!, needs_parentheses, parent_type,
+             parent, primpart, promote_rule, reconstruct, show_minus_one,
+             terms, zero!, ResidueRing
 
 export base_ring, elem_type, parent_type, parent
 

--- a/src/ideal/IdealTypes.jl
+++ b/src/ideal/IdealTypes.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-const IdealSetID = Dict{Ring, Set}()
+const IdealSetID = Dict{PolyRing, Set}()
 
 mutable struct IdealSet{T <: Nemo.RingElem} <: Set
    base_ring::PolyRing

--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -1,5 +1,5 @@
 export sideal, IdealSet, syz, lead, normalize!, isconstant, iszerodim, fres,
-       sres, intersection, quotient, reduce, eliminate, kernel, equal,
+       ngens, sres, intersection, quotient, reduce, eliminate, kernel, equal,
        contains, isvar_generated, saturation, satstd, slimgb, std
 
 ###############################################################################
@@ -464,7 +464,7 @@ function fres(id::sideal{T}, max_length::Int, method::String = "complete") where
    max_length < 0 && error("length for fres must not be negative")
    R = base_ring(id)
    if max_length == 0
-        max_length = ngens(R)
+        max_length = nvars(R)
         # TODO: consider qrings
    end
    if (method != "complete"
@@ -489,7 +489,7 @@ function sres(I::sideal{T}, max_length::Int) where T <: Nemo.RingElem
    I.isGB == false && error("Not a Groebner basis ideal")
    R = base_ring(I)
    if max_length == 0
-        max_length = ngens(R)
+        max_length = nvars(R)
         # TODO: consider qrings
    end
    r, length, minimal = libSingular.id_sres(I.ptr, Cint(max_length + 1), R.ptr)

--- a/src/matrix/MatrixTypes.jl
+++ b/src/matrix/MatrixTypes.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-const MatrixSpaceID = Dict{Tuple{Ring, Int, Int}, Set}()
+const MatrixSpaceID = Dict{Tuple{PolyRing, Int, Int}, Set}()
 
 mutable struct MatrixSpace{T <: Nemo.RingElem} <: Set
    base_ring::PolyRing

--- a/src/module/ModuleTypes.jl
+++ b/src/module/ModuleTypes.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-const FreeModID = Dict{Tuple{Ring, Int}, Module}()
+const FreeModID = Dict{Tuple{PolyRing, Int}, Module}()
 
 mutable struct FreeMod{T <: Nemo.RingElem} <: Module{T}
    base_ring::PolyRing
@@ -44,7 +44,7 @@ end
 #
 ###############################################################################
 
-const ModuleClassID = Dict{Ring, Set}()
+const ModuleClassID = Dict{PolyRing, Set}()
 
 mutable struct ModuleClass{T <: Nemo.RingElem} <: Set
    base_ring::PolyRing

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -157,7 +157,7 @@ function sres(I::smodule{T}, max_length::Int) where T <: Nemo.RingElem
    I.isGB == false && error("Not a Groebner basis ideal")  
    R = base_ring(I)
    if max_length == 0
-        max_length = ngens(R)
+        max_length = nvars(R)
         # TODO: consider qrings
    end
    r, length, minimal = libSingular.id_sres(I.ptr, Cint(max_length + 1), R.ptr)

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -5,9 +5,9 @@
 ###############################################################################
 
 const PolyRingID = Dict{Tuple{Union{Ring, Field}, Array{Symbol, 1},
-         libSingular.rRingOrder_t, libSingular.rRingOrder_t, Int}, Ring}()
+         libSingular.rRingOrder_t, libSingular.rRingOrder_t, Int}, Nemo.MPolyRing}()
 
-mutable struct PolyRing{T <: Nemo.RingElem} <: Ring
+mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
    ptr::libSingular.ring
    base_ring::Union{Ring, Field}
    refcount::Int

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -69,20 +69,20 @@ function _PolyRing_clear_fn(R::PolyRing)
    end
 end
 
-mutable struct spoly{T <: Nemo.RingElem} <: Nemo.RingElem
+mutable struct spoly{T <: Nemo.RingElem} <: Nemo.MPolyElem{T}
    ptr::libSingular.poly
    parent::PolyRing{T}
 
    function spoly{T}(R::PolyRing{T}) where T <: Nemo.RingElem
       p = libSingular.p_ISet(0, R.ptr)
-	  z = new(p, R)
+      z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
    end
     
    function spoly{T}(R::PolyRing{T}, p::libSingular.poly) where T <: Nemo.RingElem
-      z = new(p, R)
+      z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
@@ -91,7 +91,7 @@ mutable struct spoly{T <: Nemo.RingElem} <: Nemo.RingElem
    function spoly{T}(R::PolyRing{T}, p::T) where T <: Nemo.RingElem
       n = libSingular.n_Copy(p.ptr, parent(p).ptr)
       r = libSingular.p_NSet(n, R.ptr)
-      z = new(r, R)
+      z = new{T}(r, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
@@ -99,7 +99,7 @@ mutable struct spoly{T <: Nemo.RingElem} <: Nemo.RingElem
     
    function spoly{T}(R::PolyRing{T}, n::libSingular.number) where T <: Nemo.RingElem
       p = libSingular.p_NSet(n, R.ptr)
-      z = new(p, R)
+      z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
@@ -107,7 +107,7 @@ mutable struct spoly{T <: Nemo.RingElem} <: Nemo.RingElem
 
    function spoly{T}(R::PolyRing{T}, b::Int) where T <: Nemo.RingElem
       p = libSingular.p_ISet(b, R.ptr)
-      z = new(p, R)
+      z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
@@ -116,7 +116,7 @@ mutable struct spoly{T <: Nemo.RingElem} <: Nemo.RingElem
    function spoly{T}(R::PolyRing{T}, b::BigInt) where T <: Nemo.RingElem
       n = libSingular.n_InitMPZ(b, R.base_ring.ptr)
       p = libSingular.p_NSet(n, R.ptr)
-      z = new(p, R)
+      z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
@@ -128,3 +128,4 @@ function _spoly_clear_fn(p::spoly)
    libSingular.p_Delete(p.ptr, R.ptr)
    _PolyRing_clear_fn(R)
 end
+

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -210,6 +210,57 @@ function Base.iterate(x::Nemo.Generic.MPolyExponentVectors{spoly{T}}, state) whe
    end
 end
 
+function Base.iterate(x::Nemo.Generic.MPolyTerms{spoly{T}}) where T <: Nemo.RingElem
+   p = x.poly
+   ptr = p.ptr
+   if ptr.cpp_object == C_NULL
+      return nothing
+   else
+      R = parent(p)
+      return R(libSingular.p_Head(ptr, R.ptr)), ptr
+   end
+end
+
+function Base.iterate(x::Nemo.Generic.MPolyTerms{spoly{T}}, state) where T <: Nemo.RingElem
+   state = libSingular.pNext(state)
+   if state.cpp_object == C_NULL
+      return nothing
+   else
+      R = parent(x.poly)
+      return R(libSingular.p_Head(state, R.ptr)), state
+   end
+end
+
+function Base.iterate(x::Nemo.Generic.MPolyMonomials{spoly{T}}) where T <: Nemo.RingElem
+   p = x.poly
+   ptr = p.ptr
+   if ptr.cpp_object == C_NULL
+      return nothing
+   else
+      S = parent(p)
+      R = base_ring(p)
+      mptr = libSingular.p_Head(ptr, S.ptr)
+      n = libSingular.n_Copy(one(R).ptr, R.ptr)
+      libSingular.p_SetCoeff0(mptr, n, S.ptr)
+      return S(mptr), ptr
+   end
+end
+
+function Base.iterate(x::Nemo.Generic.MPolyMonomials{spoly{T}}, state) where T <: Nemo.RingElem
+   state = libSingular.pNext(state)
+   if state.cpp_object == C_NULL
+      return nothing
+   else
+      p = x.poly
+      S = parent(p)
+      R = base_ring(p)
+      mptr = libSingular.p_Head(state, S.ptr)
+      n = libSingular.n_Copy(one(R).ptr, R.ptr)
+      libSingular.p_SetCoeff0(mptr, n, S.ptr)
+      return S(mptr), state
+   end
+end
+
 ###############################################################################
 #
 #   String I/O

--- a/src/resolution/ResolutionTypes.jl
+++ b/src/resolution/ResolutionTypes.jl
@@ -4,7 +4,7 @@
 #
 ###############################################################################
 
-const ResolutionSetID = Dict{Ring, Set}()
+const ResolutionSetID = Dict{PolyRing, Set}()
 
 mutable struct ResolutionSet{T <: Nemo.RingElem} <: Set
    base_ring::PolyRing

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -101,14 +101,6 @@ function test_spoly_manipulation()
    @test length(x^2 + 2x + 1) == 3
    @test degree(x^2 + 2x + 1) == 2
 
-   @test exponent(x^5 + 3x + 2, 2) == [5]
-   
-   A = [0]
-
-   exponent!(A, x^5 + 3x + 2, 2)
-
-   @test A == [5]
-
    @test lead_exponent(x^3 + 2x + 1) == [3]
 
    @test deepcopy(x + 2) == x + 2
@@ -117,16 +109,9 @@ function test_spoly_manipulation()
 
    @test ngens(R) == 1
    pol = x^5 + 3x + 2
-   c_iter = coeffs_expos(pol)
    
-   i = length(pol) - 1
-
-   for (c, ex) in c_iter
-      @test coeff(pol, i) == c      
-      @test exponent(pol, i) == ex 
-      i -= 1
-    end
-   
+   @test length(collect(coeffs(pol))) == length(pol)
+   @test length(collect(exponent_vectors(pol))) == length(pol)
    
    R, (x, ) = PolynomialRing(ResidueRing(ZZ, 6), ["x", ])
 

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -112,7 +112,16 @@ function test_spoly_manipulation()
    
    @test length(collect(coeffs(pol))) == length(pol)
    @test length(collect(exponent_vectors(pol))) == length(pol)
-   
+
+   polzip = zip(coeffs(pol), monomials(pol), terms(pol))
+   r = R()
+   for (c, m, t) in polzip
+      r += c*m
+      @test t == c*m
+   end
+
+   @test pol == r
+    
    R, (x, ) = PolynomialRing(ResidueRing(ZZ, 6), ["x", ])
 
    @test characteristic(R) == 6

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -72,6 +72,16 @@ function test_spoly_constructors()
    @test length(symbols(R)) == 2
    @test symbols(R) == [:x, :y]
 
+   R, (x, y) = PolynomialRing(ZZ, ["x", "y"]; ordering=:lex)
+
+   M = MPolyBuildCtx(R)
+   push_term!(M, ZZ(2), [1, 2])
+   push_term!(M, ZZ(1), [1, 1])
+   push_term!(M, ZZ(2), [3, 2])
+   f = finish(M)
+
+   @test f == 2*x^3*y^2+2*x*y^2+x*y
+
    println("PASS")
 end
 
@@ -107,7 +117,7 @@ function test_spoly_manipulation()
 
    @test characteristic(R) == 0
 
-   @test ngens(R) == 1
+   @test nvars(R) == 1
    pol = x^5 + 3x + 2
    
    @test length(collect(coeffs(pol))) == length(pol)
@@ -126,8 +136,8 @@ function test_spoly_manipulation()
 
    @test characteristic(R) == 6
 
-   R,(x,y) = PolynomialRing(QQ,["x", "y"])
-   p = x+y
+   R, (x, y) = PolynomialRing(QQ, ["x", "y"])
+   p = x + y
    q = x
    @test Singular.substitute_variable(p, 2, q) == 2*x
    @test Singular.permute_variables(q, [2, 1], R) == y


### PR DESCRIPTION
* Removes functions for random access of Singular polys
* Adds iterators for coeffs, monomials, terms and exponent_vectors in line with AbstractAlgebra interface
* Removes old iterator code in preference for structs already in AbstractAlgebra
* Fixes test code
* Makes spoly{T} belong to AbstractAlgebra.MPolyElem{T}
* Adds MPolyBuildCtx functions for constructing polynomials