### PR TITLE
construct n_Q from Rational{Int}

### DIFF
--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -336,6 +336,8 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 (::Rationals)(n::Int, m::Int) = n_Q(n) // n_Q(m)
 
+(::Rationals)(x::Rational{Int}) = n_Q(numerator(x)) // n_Q(denominator(x))
+
 (R::Rationals)(x::Integer) = R(libSingular.n_InitMPZ(BigInt(x), R.ptr)) 
 
 (::Rationals)(n::n_Z) = n_Q(n)

--- a/test/number/n_Q-test.jl
+++ b/test/number/n_Q-test.jl
@@ -39,6 +39,11 @@ function test_n_Q_constructors()
 
    @test isa(h, n_Q)
 
+   i = QQ(1//2)
+
+   @test isa(i, n_Q)
+   @test i == QQ(1) // QQ(2)
+
    println("PASS")
 end
 


### PR DESCRIPTION
This allows to coerce rationals from AbstractAlgebra.qq into Singular.QQ as in the following example:

`Singular.QQ(AbstractAlgebra.qq(1/2))`