### PR TITLE
construct n_Q from Rational{BigInt}

### DIFF
--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -338,6 +338,8 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 (::Rationals)(x::Rational{Int}) = n_Q(numerator(x)) // n_Q(denominator(x))
 
+(R::Rationals)(x::Rational{BigInt}) = R(Nemo.ZZ(numerator(x))) // R(Nemo.ZZ(denominator(x)))
+
 (R::Rationals)(x::Integer) = R(libSingular.n_InitMPZ(BigInt(x), R.ptr)) 
 
 (::Rationals)(n::n_Z) = n_Q(n)

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -338,7 +338,7 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 (::Rationals)(x::Rational{Int}) = n_Q(numerator(x)) // n_Q(denominator(x))
 
-(R::Rationals)(x::Rational{BigInt}) = R(Nemo.ZZ(numerator(x))) // R(Nemo.ZZ(denominator(x)))
+(R::Rationals)(x::Rational{BigInt}) = R(numerator(x)) // R(denominator(x))
 
 (R::Rationals)(x::Integer) = R(libSingular.n_InitMPZ(BigInt(x), R.ptr)) 
 

--- a/test/number/n_Q-test.jl
+++ b/test/number/n_Q-test.jl
@@ -43,6 +43,11 @@ function test_n_Q_constructors()
 
    @test isa(i, n_Q)
    @test i == QQ(1) // QQ(2)
+   
+   j = QQ(BigInt(1)//BigInt(2))
+
+   @test isa(j, n_Q)
+   @test j == QQ(1) // QQ(2)
 
    println("PASS")
 end


### PR DESCRIPTION
This allows to coerce rationals from AbstractAlgebra.QQ into Singular.QQ as in the following example:

Singular.QQ(AbstractAlgebra.QQ(1//2))

I guess it would be more efficient to coerce to Nemo.QQ first and then to Singular.QQ, but the latter is not (yet) possible. See #86.