### PR TITLE
remove the "julia" argument for deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,7 +25,6 @@ makedocs(
 )
 
 deploydocs(
-   julia = "nightly",
    repo   = "github.com/wbhart/Singular.jl.git",
    target = "build",
    deps = Deps.pip("pygments", "mkdocs", "python-markdown-math"),


### PR DESCRIPTION
as it is removed

Is the documentation actually available anywhere online?