### PR TITLE
add missing println("PASS")

### DIFF
--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -402,6 +402,7 @@ end
 
 function test_convert_between_MPoly_and_SingularPoly()
    print("spoly.test_convert_MPoly_to_SingularPoly...")
+   
    for num_vars=2:10
       var_names = ["x$j" for j in 1:num_vars]
       ord = AbstractAlgebra.rand_ordering()
@@ -427,6 +428,8 @@ function test_convert_between_MPoly_and_SingularPoly()
       @test SAA(f - g) == SAA(f) - SAA(g)
       @test S(SAA(f)) == f
    end
+   
+   println("PASS")
 end
 
 function test_spoly_differential()


### PR DESCRIPTION
in `test_convert_between_MPoly_and_SingularPoly`

BTW: The call of this function was commented out in 3a249dfde.

@wbhart Is the bug you refer to in your comment in https://github.com/oscar-system/Singular.jl/blob/1410f672bd66a3c9f62340351d4a5274ec0ca14b/test/poly/spoly-test.jl#L461 in AbstractAlgebra documented anywhere?  