### PR TITLE
make link to source code point to oscar-system

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ written by Oleksandr Motsak, William Hart and other contributors, and is maintai
 William Hart, Hans Schoenemann and Andreas Steenpas. It is part of the Oscar project.
 
 - [https://www.singular.uni-kl.de/](https://www.singular.uni-kl.de/) (Singular website)
-- [https://github.com/wbhart/Singular.jl](https://github.com/wbhart/Singular.jl) (Singular.jl source code)
+- [https://github.com/oscar-system/Singular.jl](https://github.com/oscar-system/Singular.jl) (Singular.jl source code)
 - [http://wbhart.github.io/Singular.jl/](http://wbhart.github.io/Singular.jl/) (Singular.jl online documentation)
 
 The features of Singular so far include:


### PR DESCRIPTION
As I understand it, the repository https://github.com/oscar-system/Singular.jl/ is supposed to be the central one for development and pull requests as well as issues are usually supposed to be placed here.