### PR TITLE
Conversion from n_Z resp. n_Q to mpz_t

### DIFF
--- a/deps/src/coeffs.cpp
+++ b/deps/src/coeffs.cpp
@@ -33,7 +33,7 @@ void singular_define_coeffs(jlcxx::Module & Singular)
     Singular.method("nCoeff_has_simple_Alloc",
                     [](coeffs x) { return nCoeff_has_simple_Alloc(x) > 0; });
 
-    Singular.method("n_GetMPZ_internal", [](void * ptr, snumber *n, coeffs x) {
+    Singular.method("n_GetMPZ_internal", [](void * ptr, number n, coeffs x) {
         n_MPZ(reinterpret_cast<__mpz_struct *>(ptr), reinterpret_cast<number&>(n), x);
     });
 

--- a/deps/src/coeffs.cpp
+++ b/deps/src/coeffs.cpp
@@ -34,7 +34,7 @@ void singular_define_coeffs(jlcxx::Module & Singular)
                     [](coeffs x) { return nCoeff_has_simple_Alloc(x) > 0; });
 
     Singular.method("n_GetMPZ_internal", [](void * ptr, number n, coeffs x) {
-        n_MPZ(reinterpret_cast<__mpz_struct *>(ptr), reinterpret_cast<number&>(n), x);
+        n_MPZ(reinterpret_cast<__mpz_struct *>(ptr), n, x);
     });
 
     Singular.method("n_InitMPZ_internal", [](void * ptr, coeffs x) {

--- a/deps/src/coeffs.cpp
+++ b/deps/src/coeffs.cpp
@@ -33,6 +33,10 @@ void singular_define_coeffs(jlcxx::Module & Singular)
     Singular.method("nCoeff_has_simple_Alloc",
                     [](coeffs x) { return nCoeff_has_simple_Alloc(x) > 0; });
 
+    Singular.method("n_GetMPZ_internal", [](void * ptr, snumber *n, coeffs x) {
+        n_MPZ(reinterpret_cast<__mpz_struct *>(ptr), reinterpret_cast<number&>(n), x);
+    });
+
     Singular.method("n_InitMPZ_internal", [](void * ptr, coeffs x) {
         return n_InitMPZ(reinterpret_cast<__mpz_struct *>(ptr), x);
     });

--- a/src/libsingular/coeffs.jl
+++ b/src/libsingular/coeffs.jl
@@ -4,6 +4,14 @@ function n_InitMPZ(b::BigInt, cf::coeffs)
     return n_InitMPZ_internal(bb, cf)
 end
 
+# get an mpz from a number
+function n_GetMPZ(s::numberRef, r::coeffs)
+   res = BigInt(1)
+   resp = pointer_from_objref(res)
+   n_GetMPZ_internal(resp, s, r)
+   return res
+end
+
 # write a number to a Singular string
 function n_Write(n::numberRef, cf::coeffs, bShortOut::Bool = false)
    d = Int(bShortOut)

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -378,6 +378,6 @@ function (R::Integers)(x::Nemo.fmpz)
 end
 
 function convert(::Type{BigInt}, n::n_Z)
-   return deepcopy(unsafe_load(reinterpret(Ptr{BigInt}, n.ptr.cpp_object)))
+  return libSingular.n_GetMPZ(n.ptr, parent(n).ptr)
 end
 


### PR DESCRIPTION
New try (compare pull PR127): The new libSingular conversion function n_GetMPZ uses  directly Singular's n_MPZ function to convert n_Z or n_Q elements to mpz_t. Note that Hans and I have found a bug in Singular concerning n_MPZ which is fixed in Singular/Sources with commit bd5ff4034c6329566588caf816d298e914084631.

I then also used this implementation for Florian's convert function he added with PR117 as Bill pointed out earlier. Again note that in order to get Florian's conversion test code pass you need a version of Singular/Sources with the above mentioned fix. 