### PR TITLE
Add error if == is used on ideals, as the meaning is ambiguous.

### DIFF
--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -226,7 +226,7 @@ function equal(I1::sideal{T}, I2::sideal{T}) where T <: AbstractAlgebra.RingElem
 end
 
 function ==(I1::sideal{T}, I2::sideal{T}) where T <: AbstractAlgebra.RingElem
-   error("For equality of ideals, please use either equal or isequal")
+   error("For equality of ideals as sets or lists, please use either equal or isequal respectively")
 end
 
 ###############################################################################

--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -225,6 +225,10 @@ function equal(I1::sideal{T}, I2::sideal{T}) where T <: AbstractAlgebra.RingElem
    return contains(I1, I2) && contains(I2, I1)
 end
 
+function ==(I1::sideal{T}, I2::sideal{T}) where T <: AbstractAlgebra.RingElem
+   error("For equality of ideals, please use either equal or isequal")
+end
+
 ###############################################################################
 #
 #   Leading terms


### PR DESCRIPTION
Fixes https://github.com/oscar-system/Singular.jl/issues/116