### PR TITLE
Changed the structure of SAlgHom and SIdAlgHom

### DIFF
--- a/deps/src/ideals.cpp
+++ b/deps/src/ideals.cpp
@@ -235,8 +235,7 @@ void singular_define_ideals(jlcxx::Module & Singular)
                     ring im) {
 
         rChangeCurrRing(pr);
-        nMapFunc nMap =n_SetMap(currRing->cf, im->cf);
-        return maMapIdeal(map_id, pr, im_id, im, nMap);
+        return maMapIdeal(map_id, pr, im_id, im, ndCopyMap);
     });
     Singular.method("idMinBase", [](ideal I, ring r) {
         rChangeCurrRing(r);

--- a/deps/src/rings.cpp
+++ b/deps/src/rings.cpp
@@ -295,8 +295,7 @@ void singular_define_rings(jlcxx::Module & Singular)
     Singular.method("maMapPoly",
                    [](poly map_p, ring pr, ideal im_id, ring im) {
                        rChangeCurrRing(pr);
-                       nMapFunc nMap =n_SetMap(currRing->cf, im->cf);
-                       return maMapPoly(map_p, pr, im_id, im, nMap);
+                       return maMapPoly(map_p, pr, im_id, im, ndCopyMap);
     });
     Singular.method("p_GetOrder",
                    [](poly p, ring r) {

--- a/docs/src/alghom.md
+++ b/docs/src/alghom.md
@@ -4,7 +4,8 @@ CurrentModule = Singular
 
 # Algebra Homomorphisms
 
-Singular.jl allows the creation of algebra homomorphisms of Singular polynomial rings over the fields `QQ`, `Fp` and finite extensions of `Fp`. 
+Singular.jl allows the creation of algebra homomorphisms of Singular polynomial rings
+over Nemo/Singular coefficient rings.
 
 The default algebra homomorphism type in Singular.jl is the Singular `SAlgHom` type.
 
@@ -17,10 +18,14 @@ All algebra homomorphism types belong directly to the abstract type `AbstractAlg
 
 ### Constructors
 
-Given two Singular polynomial rings $R$ and $S$ over the same base field $K$, the following constructors are available for creating ideals.
+Given two Singular polynomial rings $R$ and $S$ over the same base ring, the following constructors are available for creating algebra homomorphisms.
 
 ```@docs
-AlgebraHomomorphism(D::PolyRing, C::PolyRing, I::sideal)
+AlgebraHomomorphism(D::PolyRing, C::PolyRing, V::Vector)
+```
+
+```@docs
+AlgebraHomomorphism(D::PolyRing, C::PolyRing, V::Vector, ptr::libSingular.ideal)
 ```
 
 ```@docs
@@ -38,9 +43,13 @@ R, (x, y, z, w) = PolynomialRing(L[1], ["x", "y", "z", "w"];
 S, (a, b, c) = PolynomialRing(L[1], ["a", "b", "c"];
                              ordering=:degrevlex)
 
-I = Ideal(S, [a, a + b^2, b - c, c + b])
+V = [a, a + b^2, b - c, c + b]
 
-f = AlgebraHomomorphism(R, S, I)
+I = Ideal(S, V)
+
+f = AlgebraHomomorphism(R, S, V)
+
+g = AlgebraHomomorphism(R, S, V, I.ptr)
 ```
 
 ### Operating on objects
@@ -50,15 +59,15 @@ It is possible to act on polynomials and ideals via algebra homomorphisms.
 **Examples**
 
 ```
-R, (x, y, z, w) = PolynomialRing(Singular.Fp(3), ["x", "y", "z", "w"];
+R, (x, y, z, w) = PolynomialRing(Nemo.ZZ, ["x", "y", "z", "w"];
                              ordering=:negdegrevlex)
    
-S, (a, b, c) = PolynomialRing(Singular.Fp(3), ["a", "b", "c"];
+S, (a, b, c) = PolynomialRing(Nemo.ZZ, ["a", "b", "c"];
                              ordering=:degrevlex)
    
-I = Ideal(S, [a, a + b^2, b - c, c + b])
+V = [a, a + b^2, b - c, c + b]
    
-f = AlgebraHomomorphism(R, S, I)
+f = AlgebraHomomorphism(R, S, V)
    
 id  = IdentityAlgebraHomomorphism(S)
 
@@ -84,22 +93,19 @@ A short command for the composition of $f$ and $g$ is `f*g`, which is the same a
 **Examples**
 
 ```
-R, (x, y, z, w) = PolynomialRing(Singular.QQ, ["x", "y", "z", "w"];
+R, (x, y, z, w) = PolynomialRing(QQ, ["x", "y", "z", "w"];
                              ordering=:negdegrevlex)
 
-S, (a, b, c) = PolynomialRing(Singular.QQ, ["a", "b", "c"];
+S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"];
                              ordering=:degrevlex)
 
-I = Ideal(S, [a, a + b^2, b - c, c + b])
+V = [a, a + b^2, b - c, c + b]
 
-K = Ideal(R, [x^2, x + y + z, z*y])
+W = [x^2, x + y + z, z*y]
 
-L = Ideal(R, [x^2, 2*x^2 + 2*x*y + y^2 + 2*x*z + 2*y*z + z^2, x + y + z - y*z,
-                x + y + z + y*z])
+f = AlgebraHomomorphism(R, S, V)
 
-f = AlgebraHomomorphism(R, S, I)
-
-g = AlgebraHomomorphism(S, R, K)
+g = AlgebraHomomorphism(S, R, W)
 
 idR  = IdentityAlgebraHomomorphism(R)
 
@@ -119,6 +125,14 @@ preimage(f::SAlgHom, I::sideal)
 ```
 
 ```@docs
+preimage(f::SIdAlgHom, I::sideal)
+```
+
+```@docs
+kernel(f::SIdAlgHom)
+```
+
+```@docs
 kernel(f::SAlgHom)
 ```
 
@@ -133,12 +147,16 @@ S, (a, b, c) = PolynomialRing(QQ, ["a", "b", "c"];
    
 I = Ideal(S, [a, a + b^2, b - c, c + b])
    
-f = SAlgebraHomomorphism(R, S, I)
+f = SAlgebraHomomorphism(R, S, gens(I), I.ptr)
    
 idS  = IdentityAlgebraHomomorphism(S)
 
-P = preimage(f, I)
+P1 = preimage(f, I)
 
-K = kernel(f)
+P2 = preimage(idS, I)
+
+K1 = kernel(f)
+
+K2 = preimage(idS)
 ```
 

--- a/src/map/MapTypes.jl
+++ b/src/map/MapTypes.jl
@@ -15,11 +15,16 @@ Map(::Type{T}) where T <: AbstractAlgebra.Map = AbstractAlgebra.Map(T)
 ###############################################################################
 
 mutable struct SIdAlgHom{T} <: AbstractAlgebra.Map{PolyRing, PolyRing,
-        Singular.AbstractAlgebraHomomorphism, SIdAlgHom} where T <: Union{Ring, Field}
+         Singular.AbstractAlgebraHomomorphism, SIdAlgHom} where T <: Union{Ring, Field}
+
    domain::PolyRing
-   image::sideal
+   image::Vector
+   ptr::libSingular.ideal
+
    function SIdAlgHom{T}(R::PolyRing) where T <: Union{Ring, Field}
-   z = new(R, Singular.MaximalIdeal(R, 1))
+      M = Singular.MaximalIdeal(R, 1)
+      z = new(R, gens(M), M.ptr)
+      return z
    end
 end
 
@@ -30,15 +35,25 @@ end
 ###############################################################################
 
 mutable struct SAlgHom{T} <: AbstractAlgebra.Map{PolyRing, PolyRing,
-          Singular.AbstractAlgebraHomomorphism, SAlgHom} where T <: Union{Ring, Field}
+         Singular.AbstractAlgebraHomomorphism, SAlgHom} where T <: Union{Ring, Field}
 
    domain::PolyRing
    codomain::PolyRing
-   image::sideal
+   image::Vector
+   ptr::libSingular.ideal
 
    function SAlgHom{T}(domain::PolyRing, codomain::PolyRing,
-                                   m::sideal) where T <: Union{Ring, Field}
-      z = new(domain, codomain, m)
+             V::Vector) where T <: Union{Ring, Field}
+
+      I = Ideal(codomain, V)
+      z = new(domain, codomain, V, I.ptr)
+      return z
+   end
+
+   function SAlgHom{T}(domain::PolyRing, codomain::PolyRing,
+             V::Vector, ptr::libSingular.ideal) where T <: Union{Ring, Field}
+
+      z = new(domain, codomain, V, ptr)
       return z
    end
 end

--- a/src/map/idalghom.jl
+++ b/src/map/idalghom.jl
@@ -45,7 +45,7 @@ function show(io::IO, M::Map(SIdAlgHom))
    println(io, "")
    println(io, "Domain: ", domain(M))
    println(io, "")
-   println(io, "Defining Equations: ", gens(M.image))
+   println(io, "Defining Equations: ", M.image)
 end
 
 ###############################################################################

--- a/test/call_interpreter-test.jl
+++ b/test/call_interpreter-test.jl
@@ -11,4 +11,5 @@ function test_call_interpreter()
     @test result[4] == ""
     @test length(result) == 4
     println("PASS")
+    println("")
 end

--- a/test/map/alghom-test.jl
+++ b/test/map/alghom-test.jl
@@ -6,11 +6,16 @@ function test_alghom_constructors()
    S, (a, b, c) = Singular.PolynomialRing(L[1], ["a", "b", "c"];
                              ordering=:degrevlex)
    I = Ideal(S, [a, a + b^2, b - c, c + b])
-   f = Singular.AlgebraHomomorphism(R, S, I)
+   f = Singular.AlgebraHomomorphism(R, S, gens(I), I.ptr)
 
    @test f.domain == R
    @test f.codomain == S
-   @test equal(f.image, I)
+   @test isequal(f.image, gens(I))
+
+   f = Singular.AlgebraHomomorphism(R, S, gens(I))
+   @test f.domain == R
+   @test f.codomain == S
+   @test isequal(f.image, gens(I))
 
    println("PASS")
 end
@@ -22,7 +27,7 @@ function test_alghom_apply()
    S, (a, b, c) = Singular.PolynomialRing(Singular.Fp(3), ["a", "b", "c"];
                              ordering=:degrevlex)
    I = Ideal(S, [a, a + b^2, b - c, c + b])
-   f = Singular.AlgebraHomomorphism(R, S, I)
+   f = Singular.AlgebraHomomorphism(R, S, gens(I), I.ptr)
    id  = Singular.IdentityAlgebraHomomorphism(S)
 
    J = Ideal(R, [x, y^3])
@@ -31,9 +36,9 @@ function test_alghom_apply()
    J1 = Ideal(S, [a, a^3 + b^6])
    p1 = b^6 + a^3 + b^2 - c^2 + a
 
-   @test equal(f(J), J1)
+   @test isequal(f(J), J1)
    @test f(p) == p1
-   @test id(I) == I
+   @test isequal(gens(id(I)), gens(I))
    @test id(f(p)) == f(p)
 
    println("PASS")
@@ -45,14 +50,14 @@ function test_alghom_compose()
                              ordering=:negdegrevlex)
    S, (a, b, c) = Singular.PolynomialRing(Singular.QQ, ["a", "b", "c"];
                              ordering=:degrevlex)
-   I = Ideal(S, [a, a + b^2, b - c, c + b])
-   K = Ideal(R, [x^2, x + y + z, z*y])
+   V = [a, a + b^2, b - c, c + b]
+   W = [x^2, x + y + z, z*y]
 
-   L = Ideal(R, [x^2, 2*x^2 + 2*x*y + y^2 + 2*x*z + 2*y*z + z^2, x + y + z - y*z,
-                x + y + z + y*z])
+   L = [x^2, 2*x^2 + 2*x*y + y^2 + 2*x*z + 2*y*z + z^2, x + y + z - y*z,
+                x + y + z + y*z]
 
-   f = Singular.AlgebraHomomorphism(R, S, I)
-   g = Singular.AlgebraHomomorphism(S, R, K)
+   f = Singular.AlgebraHomomorphism(R, S, V)
+   g = Singular.AlgebraHomomorphism(S, R, W)
    idR  = Singular.IdentityAlgebraHomomorphism(R)
    idS  = Singular.IdentityAlgebraHomomorphism(S)
 
@@ -61,12 +66,10 @@ function test_alghom_compose()
    h3 = idR*f
    h4 = idR*idR
 
-   @test h1.domain == R && h1.codomain == R && equal(h1.image, L)
-   @test h2.domain == R && h2.codomain == S && equal(h2.image,
-                              MaximalIdeal(S, 1))
-   @test h3.domain == R && h3.codomain == S && equal(h3.image,
-                              MaximalIdeal(S, 1))
-   @test h4.domain == R && equal(h4.image, MaximalIdeal(R, 1))
+   @test h1.domain == R && h1.codomain == R && isequal(h1.image, L)
+   @test h2.domain == R && h2.codomain == S && isequal(h2.image, V)
+   @test h3.domain == R && h3.codomain == S && isequal(h3.image, V)
+   @test h4.domain == R && isequal(h4.image, gens(MaximalIdeal(R, 1)))
 
    println("PASS")
 end
@@ -79,13 +82,13 @@ function test_alghom_preimage()
                              ordering=:degrevlex)
    I = Ideal(S, [a, a + b^2, b - c, c + b])
 
-   f = Singular.AlgebraHomomorphism(R, S, I)
+   f = Singular.AlgebraHomomorphism(R, S, gens(I), I.ptr)
    idS  = Singular.IdentityAlgebraHomomorphism(S)
 
-   @test equal(Singular.preimage(f, I), MaximalIdeal(R, 1))
-   @test equal(Singular.kernel(f), Ideal(R, 4*x - 4*y + z^2 + 2*z*w + w^2))
-   @test equal(Singular.preimage(idS, I), I)
-   @test equal(Singular.kernel(idS), Ideal(S,))
+   @test isequal(Singular.preimage(f, I), MaximalIdeal(R, 1))
+   @test isequal(Singular.kernel(f), Ideal(R, 4*x - 4*y + z^2 + 2*z*w + w^2))
+   @test isequal(Singular.preimage(idS, I), I)
+   @test isequal(Singular.kernel(idS), Ideal(S,))
 
    println("PASS")
 end


### PR DESCRIPTION
A vector of polynomials defines the image of the ring variables and not an ideal.
Since Singular uses ideals internally, a pointer of a Singular ideal is
additionally stored in the algebra homomorphisms.

Tests and documentation have been updated.
C - code has been changed, such that the maps now work also over Nemo rings,
as long as the domain and codomain have the same base ring.