### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:


### PR DESCRIPTION
Enable testing on 1.3, which is currently julia 1.3-rc3. Disallow failures on OSX (except for master).

I want to see if https://github.com/oscar-system/Singular.jl/issues/159 happens also in the soon to be released julia 1.3.