### PR TITLE
Add basic thread safety functionality.

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${singular_includes}/singular)
 SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -g" )
 SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -L${JULIA_LIB_DIR} -Wl,-rpath,${JULIA_LIB_DIR} -L${singular_libdir} -Wl,-rpath,${singular_libdir}" )
 
-add_library(singularwrap SHARED singular.cpp rings.cpp coeffs.cpp ideals.cpp matrices.cpp caller.cpp coeff_rings.cpp)
+add_library(singularwrap SHARED singular.cpp rings.cpp coeffs.cpp ideals.cpp matrices.cpp caller.cpp coeff_rings.cpp threading.cpp)
 
 target_link_libraries(singularwrap JlCxx::cxxwrap_julia -ljulia "-lSingular -lpolys -lsingular_resources -lfactory -lomalloc -ldl -lgmp")
 

--- a/deps/src/threading.cpp
+++ b/deps/src/threading.cpp
@@ -1,0 +1,5 @@
+#include "threading.h"
+
+namespace singularjl {
+    std::recursive_mutex global_singular_lock;
+}

--- a/deps/src/threading.h
+++ b/deps/src/threading.h
@@ -1,0 +1,17 @@
+#include <mutex>
+
+#ifdef THREADSAFE_SINGULAR
+
+namespace singularjl {
+    extern std::recursive_mutex global_singular_lock;
+}
+
+#define ENTER_SINGULAR (singularjl::global_singular_lock.lock())
+#define LEAVE_SINGULAR (singularjl::global_singular_lock.unlock())
+
+#else
+
+#define ENTER_SINGULAR ((void) 0)
+#define LEAVE_SINGULAR ((void) 0)
+
+#endif


### PR DESCRIPTION
This provides some basic thread safety functionality using recursive mutexes to implement `ENTER_SINGULAR` and `LEAVE_SINGULAR` macros.

By default, these are no-ops for now, unless `THREADSAFE_SINGULAR` is defined. This is so they currently won't impede performance. Once code has been annotated with these macros, we can benchmark performance and tweak the implementation so that overhead is minimized.

In this context, I am looking specifically at so-called "biased locks." Biased locks assume that locks will most commonly be acquired by the same thread that previously held them and optimizes for that as the fast path, at the cost of making it more complicated to hand them over to other threads. As we expect that most locking operations will occur on one thread at a time, this is a reasonable scenario to optimize for right now.

Once we get around to integrating parallel Singular, the `ENTER_SINGULAR` macro can also be used to ensure that the thread state is properly initialized and `LEAVE_SINGULAR` becomes a no-op in that case.