### PR TITLE
Travis: turn on bounds check for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ coveralls: true
 
 julia:
   - 1.0
-  - 1.1
+  #- 1.1  # runs into a GC bug
   - 1.2
   - 1.3
   - nightly
@@ -32,9 +32,6 @@ matrix:
     - os: osx
 notifications:
   - email: false
-script:
-  - julia --color=yes -e 'using Pkg; if VERSION >= v"1.1.0"; Pkg.build(verbose=true); else Pkg.build(); end;'
-  - julia --color=yes -e 'using Pkg; Pkg.test();'
 
 env:
    global:
@@ -48,4 +45,3 @@ jobs:
        script:
          - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(path=pwd())); Pkg.instantiate();'
          - julia --color=yes --project=docs/ docs/make.jl
-       after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 [compat]
 AbstractAlgebra = "^0.8.0"
 Nemo = "^0.16.0"
-julia = "1.0, 1.1, 1.2"
+julia = "1.0, 1.1, 1.2, 1.3"
 CxxWrap = "^0.8.1"
 BinaryProvider = "^0.5.8"
 


### PR DESCRIPTION
With this, we basically match the default script used by Travis; so if this PR passes, we could simplify things further by just dropping the `script`.

Alas, I suspect it will fail, as PR #192 failed when I did the same...

UPDATE: Indeed, the 1.1 tests failed with some crash in the GC code. I've now disabled 1.1. Also added Julia 1.3 to Package.toml