### PR TITLE
Fixed typos in "n_transExt.jl", "ideal.jl" and "transExt.md"

### DIFF
--- a/docs/src/transExt.md
+++ b/docs/src/transExt.md
@@ -36,7 +36,7 @@ The following constructors are available to create function fields and their ele
 Singular.FunctionField(::Field, ::Array{String, 1}; ::Bool)
 ```
 
-In case the user does not want to specify a transcendece basis the following 
+In case the user does not want to specify a transcendence basis the following
 constructor can be used.
 
 ```@docs

--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -697,7 +697,7 @@ end
 > Returns, by default, an array containing a maximal independet set of
 > $lead(I)$. $I$ has to be given by a Gröbner basis.
 > If the additional parameter "all" is set to true, an array containing
-> all maximal independent sets iof $lead(I)$ is returned.
+> all maximal independent sets of $lead(I)$ is returned.
 """
 function maximal_independent_set(I::sideal{S}; all::Bool = false) where S <: Union{spoly{T}, spoly{n_unknown{U}}} where {T <: Singular.FieldElem, U <: Nemo.FieldElem}
    I.isGB == false && error("I needs to be a Gröbner basis.")

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -19,13 +19,13 @@ base_ring(a::N_FField) = a.base_ring
 
 @doc Markdown.doc"""
     transcendence_degree(F::N_FField)
-> Return the trancendence degree of the given function field.
+> Return the transcendence degree of the given function field.
 """
 transcendence_degree(F::N_FField) = Int(libSingular.rPar(F.ptr))
 
 @doc Markdown.doc"""
     basis(F::N_FField)
-> Return the trancendence basis of the given function field.
+> Return the transcendence basis of the given function field.
 """
 function transcendence_basis(F::N_FField)
    n = transcendence_degree(F)
@@ -105,7 +105,7 @@ end
 @doc Markdown.doc"""
    n_transExt_to_spoly(x::n_transExt; parent::PolyRing)
 > Returns the numerator of $x$ as a polynomial in a polynomial
-> ring with the same number of variables, as the
+> ring with at least as many variables, as the
 > transcendence degree of $parent(x)$. If a ring $parent_ring$ is
 > given to the function, it will be the parent ring of the output.
 """
@@ -116,7 +116,7 @@ function n_transExt_to_spoly(x::n_transExt; cached = true,
    n = transcendence_degree(R)
    S = parent_ring
 
-   if B != base_ring(S) || n != nvars(S)
+   if B != base_ring(S) || n > nvars(S)
       error("Base rings do not match.")
    end
    return S(Singular.libSingular.transExt_to_poly(x.ptr, R.ptr, S.ptr))


### PR DESCRIPTION
Fixed small typos in the documentation resp. the code of "n_transExt_to_spoly"