### PR TITLE
update travis dist to ubuntu bionic for gcc 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# Force Ubuntu 16.04 "Xenial" to get newer GCC, binutils etc.
-dist: xenial
+# Force Ubuntu 18.04 "Bionic" to get even newer GCC, binutils etc.
+dist: bionic
 
 addons:
     apt:


### PR DESCRIPTION
gcc 7 has better support for C++17 (needed for cxxwrap 0.9.0)