### PR TITLE
updated .travis.yml -> test with 1.4 allowing to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,23 +25,27 @@ julia:
   #- 1.1  # runs into a GC bug
   - 1.2
   - 1.3
+  - 1.4
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-    - os: osx
-notifications:
-  - email: false
-
+  
 env:
-   global:
-      - DOCUMENTER_DEBUG=true
+  global:
+    - DOCUMENTER_DEBUG=true
 
 jobs:
-   include:
-     - stage: "Documentation"
-       julia: 1.0
-       os: linux
-       script:
-         - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(path=pwd())); Pkg.instantiate();'
-         - julia --color=yes --project=docs/ docs/make.jl
+  allow_failures:
+    - julia: 1.4
+    - julia: nightly
+    - os: osx
+  fast_finish: true
+  include:
+    - stage: "Documentation"
+      name: "HTML"
+      julia: 1.3
+      os: linux
+      script:
+        - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(path=pwd())); Pkg.instantiate();'
+        - julia --color=yes --project=docs/ docs/make.jl
+
+notifications:
+  - email: false


### PR DESCRIPTION
* test with (pre-release) 1.4, allowing to fail
* jobs is an alias of matrix (so unify both sections)
* build docu with julia-1.3