### PR TITLE
Switch to CxxWrap 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ codecov: true
 coveralls: true
 
 julia:
-  - 1.0
-  #- 1.1  # runs into a GC bug
-  - 1.2
   - 1.3
   - 1.4
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Singular"
 uuid = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -18,9 +18,9 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 AbstractAlgebra = "^0.9.0"
 BinaryProvider = "^0.5.8"
 CMake = "^1.1.1"
-Nemo = "^0.17.0"
+CxxWrap = "^0.10.1"
 julia = "1.0"
-CxxWrap = "^0.9.1"
+Nemo = "^0.17.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/LibSingular.jl
+++ b/src/LibSingular.jl
@@ -2,7 +2,13 @@ module libSingular
 
 import Libdl
 using CxxWrap
-@wrapmodule(realpath(joinpath(@__DIR__, "..", "deps", "usr", "lib", "libsingularwrap." * Libdl.dlext)))
+
+const libsingularwrap_path = joinpath(@__DIR__, "..", "deps", "usr",
+                "lib", "libsingularwrap." * Libdl.dlext)
+if !isfile(libsingularwrap_path)
+    error("""Singular.jl needs to be compiled; please run `using Pkg; Pkg.build("Singular")`""")
+end
+@wrapmodule(realpath(libsingularwrap_path))
 
 function __init__()
    @initcxx

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -51,9 +51,12 @@ export ZZ, QQ, FiniteField, FunctionField, CoefficientRing, Fp
 ###############################################################################
 
 const pkgdir = realpath(joinpath(dirname(@__FILE__), ".."))
-const libsingular = joinpath(pkgdir, "deps", "usr", "lib", "libSingular")
-
-prefix = realpath(joinpath(pkgdir, "deps", "usr"))
+const prefix = joinpath(pkgdir, "deps", "usr")
+const libsingular = joinpath(prefix, "lib", "libSingular")
+const binSingular = joinpath(prefix, "bin", "Singular")
+if !isfile(binSingular)
+    error("""Singular.jl needs to be compiled; please run `using Pkg; Pkg.build("Singular")`""")
+end
 
 mapping_types = nothing
 mapping_types_reversed = nothing
@@ -61,8 +64,6 @@ mapping_types_reversed = nothing
 function __init__()
 
    # Initialise Singular
-
-   binSingular = joinpath(prefix, "bin", "Singular")
    ENV["SINGULAR_EXECUTABLE"] = binSingular
    libSingular.siInit(binSingular)
    # set up Singular parents (we cannot do this before Singular is initialised)


### PR DESCRIPTION
This upgrades to [CxxWrap 0.10.0 (release notes here)](https://github.com/JuliaInterop/CxxWrap.jl/issues/223). Of course this should only be merged in close coordination with `Polymake.jl`, in particular @saschatimme and @kalmarek ; see also https://github.com/oscar-system/Polymake.jl/pull/238

Whether we want to merge this now or later I don't know, but I wanted to test it now to see if everything works with CxxWrap 0.10.0; also, whether it has any effect on the crashes with see with the Julia nightly build...
