### PR TITLE
Properly restore working directory in parselibs.jl

### DIFF
--- a/deps/parselibs.jl
+++ b/deps/parselibs.jl
@@ -13,8 +13,6 @@ end
 
 libparsepath = abspath(joinpath(@__DIR__, "usr", "bin", "libparse"))
 
-library_dir = ""
-
 if haskey(ENV, "SINGULAR_LIBRARY_DIR")
     library_dir = ENV["SINGULAR_LIBRARY_DIR"]
 else
@@ -33,26 +31,23 @@ output_filename = abspath(joinpath(@__DIR__, "..", "src", "libraryfuncdictionary
   All other columns (containing info such as line numbers, library name, etc)
   are ignored.
 =#
-olddir = pwd()
-cd(abspath(joinpath(@__DIR__, "usr", "bin")))
-
-open(output_filename, "w") do outputfile
-    println(outputfile, "libraryfunctiondictionary = Dict(")
-    for i in filenames
-        full_path = joinpath(library_dir, i)
-        libs = execute(`$libparsepath $full_path`)
-        if libs.stderr != ""
-            error("from libparse: $(libs.stderr)")
+cd(abspath(joinpath(@__DIR__, "usr", "bin"))) do
+    open(output_filename, "w") do outputfile
+        println(outputfile, "libraryfunctiondictionary = Dict(")
+        for i in filenames
+            full_path = joinpath(library_dir, i)
+            libs = execute(`$libparsepath $full_path`)
+            if libs.stderr != ""
+                error("from libparse: $(libs.stderr)")
+            end
+            libs_splitted = split(libs.stdout,"\n")[4:end - 1]
+            libs_splitted = [split(i, " ", keepempty = false) for i in libs_splitted]
+            println(outputfile, ":$(i[1:end - 4]) => [")
+            for j in libs_splitted
+                println(outputfile, """[ "$(j[1])", "$(j[3])" ],""")
+            end
+            println(outputfile, "],\n")
         end
-        libs_splitted = split(libs.stdout,"\n")[4:end - 1]
-        libs_splitted = [split(i, " ", keepempty = false) for i in libs_splitted]
-        println(outputfile, ":$(i[1:end - 4]) => [")
-        for j in libs_splitted
-            println(outputfile, """[ "$(j[1])", "$(j[3])" ],""")
-        end
-        println(outputfile, "],\n")
+        println(outputfile, ")\n")
     end
-    println(outputfile, ")\n")
 end
-
-cd(pwd)


### PR DESCRIPTION
This is based on suggestions in https://github.com/JuliaInterop/CxxWrap.jl as well as on https://github.com/JuliaInterop/libcxxwrap-julia/blob/master/testlib-builder/src/testlib/CMakeLists.txt