### PR TITLE
Better error if package was not built; improve deps/build.jl

### DIFF
--- a/src/LibSingular.jl
+++ b/src/LibSingular.jl
@@ -2,7 +2,13 @@ module libSingular
 
 import Libdl
 using CxxWrap
-@wrapmodule(realpath(joinpath(@__DIR__, "..", "deps", "usr", "lib", "libsingularwrap." * Libdl.dlext)))
+
+const libsingularwrap_path = joinpath(@__DIR__, "..", "deps", "usr",
+                "lib", "libsingularwrap." * Libdl.dlext)
+if !isfile(libsingularwrap_path)
+    error("""Singular.jl needs to be compiled; please run `using Pkg; Pkg.build("Polymake")`""")
+end
+@wrapmodule(realpath(libsingularwrap_path))
 
 function __init__()
    @initcxx

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -51,9 +51,12 @@ export ZZ, QQ, FiniteField, FunctionField, CoefficientRing, Fp
 ###############################################################################
 
 const pkgdir = realpath(joinpath(dirname(@__FILE__), ".."))
-const libsingular = joinpath(pkgdir, "deps", "usr", "lib", "libSingular")
-
-prefix = realpath(joinpath(pkgdir, "deps", "usr"))
+const prefix = joinpath(pkgdir, "deps", "usr")
+const libsingular = joinpath(prefix, "lib", "libSingular")
+const binSingular = joinpath(prefix, "bin", "Singular")
+if !isfile(binSingular)
+    error("""Singular.jl needs to be compiled; please run `using Pkg; Pkg.build("Polymake")`""")
+end
 
 mapping_types = nothing
 mapping_types_reversed = nothing
@@ -61,8 +64,6 @@ mapping_types_reversed = nothing
 function __init__()
 
    # Initialise Singular
-
-   binSingular = joinpath(prefix, "bin", "Singular")
    ENV["SINGULAR_EXECUTABLE"] = binSingular
    libSingular.siInit(binSingular)
    # set up Singular parents (we cannot do this before Singular is initialised)


### PR DESCRIPTION
- if the package was not built resp. the build failed, then we now print a more helpful error message, instead of just an exception thrown by `realpath`
- separate the cmake build directory from the source directory
- when rebuilding, force a full rebuild by deleting the build directory at the start
- reformat initial cmake invocation for readability
- replace `make && make install` by `cmake --build && cmake --install`