### PR TITLE
Test with older macOS/Xcode versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ jobs:
     - julia: nightly
   fast_finish: true
   include:
+    - os: osx
+      osx_image: xcode9.2 # latest version available for macOS 10.12 Sierra
+
     - stage: "Documentation"
       name: "HTML"
       julia: 1.3


### PR DESCRIPTION
@wdecker is seeing crashes related to CxxWrap when building Singular.jl and Polymake.jl ; he is using Xcode 9.2 on macOS 10.12. Before I go and install a VM of that to investigate, let's see if they work fine on Travis. While at it, also test on the oldest macOS / Xcode version Travis has