### PR TITLE
Require Julia >= 1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ AbstractAlgebra = "^0.9.0"
 BinaryProvider = "^0.5.8"
 CMake = "^1.1.1"
 CxxWrap = "^0.10.1"
-julia = "1.0"
+julia = "1.3"
 Nemo = "^0.17.0"
 
 [extras]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ The features of Singular so far include:
 
 ## Installation
 
-To use Singular.jl we require Julia 1.0 or higher. Please see
+To use Singular.jl we require Julia 1.3 or higher. Please see
 [http://julialang.org/downloads](http://julialang.org/downloads/) for instructions on
 how to obtain julia for your system.
 


### PR DESCRIPTION
... since we are now using a JLL package, which generally requires Julia >= 1.3

Closes #243 

Two alternatives come to mind:
1. it would be possible to insert code which can be used in Julia 1.0-1.2 to substitute for the JLLs (see https://github.com/oscar-system/LoadFlint.jl/pull/4)
2. We could just accept that 4ti2 won't work in older Julia versions, and just disable any code (and tests) using it there.

That said, I think we should just merge this PR, it's the least work, and long term we will want to require the next Julia LTS anyway (right now it looks good for Julia 1.6 becoming that, but time will tell...)