### PR TITLE
Fix missing promote rule

### DIFF
--- a/src/LibSingular.jl
+++ b/src/LibSingular.jl
@@ -3,6 +3,8 @@ module libSingular
 import Libdl
 using CxxWrap
 
+import ..Singular: libflint, libantic
+
 const libsingularwrap_path = joinpath(@__DIR__, "..", "deps", "usr",
                 "lib", "libsingularwrap." * Libdl.dlext)
 if !isfile(libsingularwrap_path)

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -55,6 +55,10 @@ const pkgdir = realpath(joinpath(dirname(@__FILE__), ".."))
 const prefix = joinpath(pkgdir, "deps", "usr")
 const libsingular = joinpath(prefix, "lib", "libSingular")
 const binSingular = joinpath(prefix, "bin", "Singular")
+
+const libflint = Nemo.libflint
+const libantic = Nemo.libantic
+
 if !isfile(binSingular)
     error("""Singular.jl needs to be compiled; please run `using Pkg; Pkg.build("Singular")`""")
 end

--- a/src/libsingular/antic/nf_elem.jl
+++ b/src/libsingular/antic/nf_elem.jl
@@ -63,7 +63,7 @@ end
 
 function nf_elemInpNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    cf_ptr = get_coeff_data_void(cf)
-   ccall((:nf_elem_neg, :libantic), Cvoid,
+   ccall((:nf_elem_neg, libantic), Cvoid,
 	 (Ptr{Nemo.nf_elem}, Ptr{Nemo.nf_elem}, Ptr{Nemo.AnticNumberField}),
 	   a, a, cf_ptr)
    return a

--- a/src/libsingular/flint/fmpq.jl
+++ b/src/libsingular/flint/fmpq.jl
@@ -61,7 +61,7 @@ function fmpqNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
 end
 
 function fmpqInpNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
-    ccall((:fmpq_neg, :libflint), Cvoid, (Ptr{Nemo.fmpq}, Ptr{Nemo.fmpq}), a, a)
+    ccall((:fmpq_neg, libflint), Cvoid, (Ptr{Nemo.fmpq}, Ptr{Nemo.fmpq}), a, a)
     return a
 end
 

--- a/src/libsingular/flint/fmpz.jl
+++ b/src/libsingular/flint/fmpz.jl
@@ -61,7 +61,7 @@ function fmpzNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
 end
 
 function fmpzInpNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
-    ccall((:fmpz_neg, :libflint), Cvoid, (Ptr{Nemo.fmpz}, Ptr{Nemo.fmpz}), a, a)
+    ccall((:fmpz_neg, libflint), Cvoid, (Ptr{Nemo.fmpz}, Ptr{Nemo.fmpz}), a, a)
     return a
 end
 

--- a/src/libsingular/flint/fq.jl
+++ b/src/libsingular/flint/fq.jl
@@ -63,7 +63,7 @@ end
 
 function fqInpNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    cf_ptr = get_coeff_data_void(cf)
-   ccall((:fq_neg, :libflint), Cvoid,
+   ccall((:fq_neg, libflint), Cvoid,
 	 (Ptr{Nemo.fq}, Ptr{Nemo.fq}, Ptr{Nemo.FqFiniteField}),
 	   a, a, cf_ptr)
    return a

--- a/src/libsingular/flint/fq_nmod.jl
+++ b/src/libsingular/flint/fq_nmod.jl
@@ -63,7 +63,7 @@ end
 
 function fq_nmodInpNeg(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    cf_ptr = get_coeff_data_void(cf)
-   ccall((:fq_nmod_neg, :libflint), Cvoid,
+   ccall((:fq_nmod_neg, libflint), Cvoid,
 	 (Ptr{Nemo.fq_nmod}, Ptr{Nemo.fq_nmod}, Ptr{Nemo.FqNmodFiniteField}),
 	   a, a, cf_ptr)
    return a

--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -333,7 +333,7 @@ end
 
 function (R::N_GField)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    z = R(libSingular.n_InitMPZ(a, R.ptr))
       z.parent = R

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -362,7 +362,7 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 function (R::Rationals)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    return R(libSingular.n_InitMPZ(a, R.ptr))   
 end

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -375,7 +375,7 @@ promote_rule(C::Type{n_Z}, ::Type{T}) where {T <: Integer} = n_Z
 
 function (R::Integers)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    return R(libSingular.n_InitMPZ(a, R.ptr))   
 end

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -333,7 +333,7 @@ end
 
 function (R::N_ZnRing)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    z = R(libSingular.n_InitMPZ(a, R.ptr))
       z.parent = R

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -321,7 +321,7 @@ end
 
 function (R::N_ZpField)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    z = R(libSingular.n_InitMPZ(a, R.ptr))
       z.parent = R

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -353,7 +353,7 @@ end
 
 function (R::N_FField)(x::Nemo.fmpz)
    a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, :libflint), Nothing,
+   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
          (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
    z = R(libSingular.n_InitMPZ(a, R.ptr))
       z.parent = R

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1011,6 +1011,10 @@ function promote_rule(::Type{spoly{T}}, ::Type{U}) where {T <: Nemo.RingElem, U 
    promote_rule(T, U) == T ? spoly{T} : Union{}
 end
 
+function promote_rule(::Type{spoly{T}}, ::Type{T}) where {T <: Nemo.RingElem}
+   return spoly{T}
+end
+
 ###############################################################################
 #
 #   Build context

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -138,6 +138,9 @@ end
    @test Singular.substitute_variable(p, 2, q) == 2*x
    @test Singular.permute_variables(q, [2, 1], R) == y
 
+   @test x * QQ(2) == QQ(2) * x
+   @test x * 2 == 2 * x
+
    for i = 1:nvars(R)
       @test gen(R, i) == gens(R)[i]
    end
@@ -153,6 +156,7 @@ end
    @test lc(3x^2 + 2x + 1) == 3
    @test lm(3x^2 + 2x + 1) == x^2
    @test lt(3x^2 + 2x + 1) == 3x^2
+
 end
 
 @testset "spoly.change_base_ring..." begin


### PR DESCRIPTION
Before:
```julia
julia> R, (x, y) = PolynomialRing(QQ, ["x", "y"])
(Singular Polynomial Ring (QQ),(x,y),(dp(2),C), spoly{n_Q}[x, y])

julia> f = x^2*y + 2x + 1
1*x^2*y + 2*x + 1

julia> x * QQ(2)
ERROR: MethodError: no method matching (::Rationals)(::spoly{n_Q})
Closest candidates are:
  Any() at /home/bla/.julia/packages/Singular/GGfzi/src/number/n_Q.jl:341
  Any(::Int64) at /home/bla/.julia/packages/Singular/GGfzi/src/number/n_Q.jl:343
  Any(::Int64, ::Int64) at /home/bla/.julia/packages/Singular/GGfzi/src/number/n_Q.jl:
```