### PR TITLE
fix a bunch of constructors taking a Nemo.fmpz

### DIFF
--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -326,17 +326,14 @@ end
 (R::N_GField)(n::n_GF) = n
 
 function (R::N_GField)(n::libSingular.number_ptr)
-   z = n_GF(R, n) 
+   z = n_GF(R, n)
    z.parent = R
    return z
 end
 
 function (R::N_GField)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   z = R(libSingular.n_InitMPZ(a, R.ptr))
-      z.parent = R
+   z = convert_from_fmpz(R, x)
+   z.parent = R
    return z
 end
 

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -357,14 +357,8 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 (::Rationals)(n::n_Q) = n
 
-(::Rationals)(n::libSingular.number_ptr) = n_Q(n) 
+(::Rationals)(n::libSingular.number_ptr) = n_Q(n)
 
 (Rational{BigInt})(x::Singular.n_Q) = convert(BigInt, numerator(x)) // convert(BigInt, denominator(x))
 
-function (R::Rationals)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   return R(libSingular.n_InitMPZ(a, R.ptr))   
-end
-
+(R::Rationals)(x::Nemo.fmpz) = convert_from_fmpz(R, x)

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -373,9 +373,11 @@ promote_rule(C::Type{n_Z}, ::Type{T}) where {T <: Integer} = n_Z
 
 (::Integers)(n::libSingular.number_ptr) = n_Z(n)
 
-function (R::Integers)(x::Nemo.fmpz)
+(R::Integers)(x::Nemo.fmpz) = convert_from_fmpz(R, x)
+
+function convert_from_fmpz(R, x::Nemo.fmpz)
    if Nemo._fmpz_is_small(x)
-      n_Z(x.d)
+      R(x.d)
    else
       mpz_facade = unsafe_load(Ptr{BigInt}(x.d << 2))
       R(libSingular.n_InitMPZ(mpz_facade, R.ptr))

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -371,13 +371,15 @@ promote_rule(C::Type{n_Z}, ::Type{T}) where {T <: Integer} = n_Z
 
 (::Integers)(n::n_Z) = n
 
-(::Integers)(n::libSingular.number_ptr) = n_Z(n) 
+(::Integers)(n::libSingular.number_ptr) = n_Z(n)
 
 function (R::Integers)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   return R(libSingular.n_InitMPZ(a, R.ptr))   
+   if Nemo._fmpz_is_small(x)
+      n_Z(x.d)
+   else
+      mpz_facade = unsafe_load(Ptr{BigInt}(x.d << 2))
+      R(libSingular.n_InitMPZ(mpz_facade, R.ptr))
+   end
 end
 
 function convert(::Type{BigInt}, n::n_Z)

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -326,17 +326,14 @@ end
 (R::N_ZnRing)(n::n_Zn) = n
 
 function (R::N_ZnRing)(n::libSingular.number_ptr)
-   z = n_Zn(R, n) 
+   z = n_Zn(R, n)
    z.parent = R
    return z
 end
 
 function (R::N_ZnRing)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   z = R(libSingular.n_InitMPZ(a, R.ptr))
-      z.parent = R
+   z = convert_from_fmpz(R, x)
+   z.parent = R
    return z
 end
 

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -314,17 +314,14 @@ end
 (R::N_ZpField)(n::n_Zp) = n
 
 function (R::N_ZpField)(n::libSingular.number_ptr)
-   z = n_Zp(R, n) 
+   z = n_Zp(R, n)
    z.parent = R
    return z
 end
 
 function (R::N_ZpField)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   z = R(libSingular.n_InitMPZ(a, R.ptr))
-      z.parent = R
+   z = convert_from_fmpz(R, x)
+   z.parent = R
    return z
 end
 

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -146,7 +146,7 @@ function show(io::IO, n::n_transExt)
    libSingular.n_Write(n.ptr, parent(n).ptr, false)
 
    m = libSingular.StringEndS()
-   
+
    print(io, m)
 end
 
@@ -160,10 +160,10 @@ show_minus_one(::Type{n_transExt}) = false
 #
 ###############################################################################
 
-function -(x::n_transExt) 
+function -(x::n_transExt)
     C = parent(x)
     ptr = libSingular.n_Neg(x.ptr, C.ptr)
-    return C(ptr) 
+    return C(ptr)
 end
 
 ###############################################################################
@@ -329,7 +329,7 @@ function (R::N_FField)()
 end
 
 function (R::N_FField)(x::Integer)
-   z = R(libSingular.n_InitMPZ(BigInt(x), R.ptr)) 
+   z = R(libSingular.n_InitMPZ(BigInt(x), R.ptr))
    z.parent = R
    return z
 end
@@ -346,17 +346,14 @@ function (R::N_FField)(n::n_transExt)
 end
 
 function (R::N_FField)(n::libSingular.number_ptr)
-   z = n_transExt(R, n) 
+   z = n_transExt(R, n)
    z.parent = R
    return z
 end
 
 function (R::N_FField)(x::Nemo.fmpz)
-   a = BigInt()
-   ccall((:flint_mpz_init_set_readonly, libflint), Nothing,
-         (Ptr{BigInt}, Ptr{fmpz}), Ref(a), Ref(x))
-   z = R(libSingular.n_InitMPZ(a, R.ptr))
-      z.parent = R
+   z = convert_from_fmpz(R, x)
+   z.parent = R
    return z
 end
 
@@ -388,4 +385,3 @@ function FunctionField(F::Singular.Field, n::Int; cached::Bool=true)
    S = ["a$i" for i in 1:n]
    return FunctionField(F, S)
 end
-

--- a/test/number/n_Z-test.jl
+++ b/test/number/n_Z-test.jl
@@ -27,6 +27,11 @@
 
    f = ZZ(Nemo.ZZ(123))
 
+   # should not crash
+   for i=1:100
+      f = ZZ(Nemo.ZZ(3)^(2*i)-1)
+   end
+
    @test isa(f, n_Z)
 end
 
@@ -38,7 +43,7 @@ end
    @test isone(one(ZZ))
    @test iszero(zero(ZZ))
    @test isunit(ZZ(1)) && isunit(ZZ(-1))
-   @test !isunit(ZZ(2)) && !isunit(ZZ(0)) 
+   @test !isunit(ZZ(2)) && !isunit(ZZ(0))
 
    @test numerator(ZZ(2)) == 2
    @test denominator(ZZ(2)) == 1


### PR DESCRIPTION
E.g. `ZZ(x::Nemo.fmpz)`.

The `flint_mpz_init_set_readonly` was called on a "Julia-managed"
`BigInt` object `a` with finalizer, but when `x` was not an
immediate integer, `a` was overwritten, which led to corruption.