### PR TITLE
fix #86, more conversions from/to n_Q

### DIFF
--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -333,6 +333,15 @@ promote_rule(C::Type{n_Q}, ::Type{Nemo.fmpz}) = n_Q
 
 promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
+Rational{T}(x::n_Q) where {T} = convert(T, numerator(x)) // convert(T, denominator(x))
+Rational(x::n_Q) = Integer(numerator(x)) // Integer(denominator(x))
+
+convert(::Type{T}, x::n_Q) where {T <: Rational} = T(x)
+
+Nemo.fmpq(x::n_Q) = fmpq(fmpz(numerator(x)), fmpz(denominator(x)))
+convert(::Type{fmpq}, x::n_Q) = fmpq(x)
+(::FlintRationalField)(x::n_Q) = fmpq(x)
+
 ###############################################################################
 #
 #   Parent call functions
@@ -341,24 +350,24 @@ promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
 
 (::Rationals)() = n_Q()
 
-(::Rationals)(n::Int) = n_Q(n)
-
 (::Rationals)(n::Int, m::Int) = n_Q(n) // n_Q(m)
-
-(::Rationals)(x::Rational{Int}) = n_Q(numerator(x)) // n_Q(denominator(x))
-
-(R::Rationals)(x::Rational{BigInt}) = R(numerator(x)) // R(denominator(x))
-
-(R::Rationals)(x::Integer) = R(libSingular.n_InitMPZ(BigInt(x), R.ptr)) 
-
-(R::Rationals)(x::Rational) = R(libSingular.n_InitMPZ(BigInt(numerator(x)), R.ptr)) // R(libSingular.n_InitMPZ(BigInt(denominator(x)), R.ptr))
-
-(::Rationals)(n::n_Z) = n_Q(n)
-
-(::Rationals)(n::n_Q) = n
 
 (::Rationals)(n::libSingular.number_ptr) = n_Q(n)
 
-(Rational{BigInt})(x::Singular.n_Q) = convert(BigInt, numerator(x)) // convert(BigInt, denominator(x))
+# from integers
 
-(R::Rationals)(x::Nemo.fmpz) = convert_from_fmpz(R, x)
+(::Rationals)(n::Int) = n_Q(n)
+
+(R::Rationals)(x::Integer) = R(libSingular.n_InitMPZ(BigInt(x), R.ptr))
+
+(::Rationals)(n::n_Z) = n_Q(n)
+
+(R::Rationals)(x::fmpz) = convert_from_fmpz(R, x)
+
+# from rationals
+
+(::Rationals)(x::Rational{Int}) = n_Q(numerator(x)) // n_Q(denominator(x))
+
+(R::Rationals)(x::Union{Rational,fmpq}) = R(numerator(x)) // R(denominator(x))
+
+(::Rationals)(n::n_Q) = n

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -350,7 +350,7 @@ convert(::Type{fmpq}, x::n_Q) = fmpq(x)
 
 (::Rationals)() = n_Q()
 
-(::Rationals)(n::Int, m::Int) = n_Q(n) // n_Q(m)
+(R::Rationals)(n::Union{Integer,fmpz,n_Z}, m::Union{Integer,fmpz,n_Z}) = R(n) // R(m)
 
 (::Rationals)(n::libSingular.number_ptr) = n_Q(n)
 

--- a/test/number/n_Q-test.jl
+++ b/test/number/n_Q-test.jl
@@ -37,6 +37,16 @@
 
    @test isa(h, n_Q)
 
+   h2 = QQ(Nemo.ZZ(2), 3)
+
+   @test isa(h2, n_Q)
+   @test h2 == 2//3
+
+   h3 = QQ(ZZ(2), ZZ(3))
+
+   @test isa(h3, n_Q)
+   @test h3 == 2//3
+
    i = QQ(1//2)
 
    @test isa(i, n_Q)

--- a/test/number/n_Q-test.jl
+++ b/test/number/n_Q-test.jl
@@ -41,11 +41,16 @@
 
    @test isa(i, n_Q)
    @test i == QQ(1) // QQ(2)
-   
+
    j = QQ(BigInt(1)//BigInt(2))
 
    @test isa(j, n_Q)
    @test j == QQ(1) // QQ(2)
+
+   k = QQ(Nemo.QQ(2, 3))
+
+   @test isa(k, n_Q)
+   @test k == QQ(2) // QQ(3)
 end
 
 @testset "n_Q.printing..." begin
@@ -154,5 +159,15 @@ end
 @testset "n_Q.conversions..." begin
    @test Singular.QQ(1//2) == Singular.QQ(1) // Singular.QQ(2)
    @test AbstractAlgebra.QQ(Singular.QQ(1) // Singular.QQ(2)) == 1//2
-end
 
+   s = Singular.QQ(1//2)
+   @test 1//2 == Rational{BigInt}(s) isa Rational{BigInt}
+   @test 1//2 == Rational(s) isa Rational{BigInt}
+   @test 1//2 == convert(Rational, s) isa Rational{BigInt}
+   @test 1//2 == Rational{Int}(s) isa Rational{Int}
+   @test 1//2 == convert(Rational{Int}, s) isa Rational{Int}
+
+   @test 1//2 == Nemo.QQ(s) isa Nemo.fmpq
+   @test 1//2 == Nemo.fmpq(s) isa Nemo.fmpq
+   @test 1//2 == convert(Nemo.fmpq, s) isa Nemo.fmpq
+end


### PR DESCRIPTION
This adds missing conversions to/from `Rational` and `fmpz` types (with constructors and `convert` methods).
The second commit also extends the `QQ(2, 3)` constructor for non-Int arguments. 