### PR TITLE
add a bunch of (::MatrixSpace)(...) constructors

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -30,6 +30,8 @@ using Random: Random, AbstractRNG, SamplerTrivial, SamplerSimple
 import Random: rand
 using RandomExtensions: RandomExtensions, make, Make2
 
+import AbstractAlgebra: AbstractAlgebra, diagonal_matrix, zero_matrix
+
 import Nemo: add!, addeq!, base_ring, canonical_unit,
              change_base_ring, characteristic, check_parent, codomain,
              coeff, coeffs, compose, contains, content, crt,

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -200,6 +200,11 @@ end
 
 (S::MatrixSpace)() = zero_matrix(S.base_ring, S.nrows, S.ncols)
 
+(S::MatrixSpace)(a::smatrix) =
+   S.base_ring == a.base_ring && S.nrows == nrows(a) && S.ncols == ncols(a) ?
+      a :
+      throw(ArgumentError("unable to coerce matrix"))
+
 ###############################################################################
 #
 #   Matrix constructors

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -198,6 +198,8 @@ function (S::MatrixSpace{T})(ptr::libSingular.matrix_ptr) where T <: AbstractAlg
    return M
 end
 
+(S::MatrixSpace)() = zero_matrix(S.base_ring, S.nrows, S.ncols)
+
 ###############################################################################
 #
 #   Matrix constructors

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -205,7 +205,7 @@ end
       a :
       throw(ArgumentError("unable to coerce matrix"))
 
-(S::MatrixSpace)(n::Integer) = diagonal_matrix(S.base_ring(n), S.nrows, S.ncols)
+(S::MatrixSpace)(x::RingElement) = diagonal_matrix(S.base_ring(x), S.nrows, S.ncols)
 
 ###############################################################################
 #

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -205,6 +205,8 @@ end
       a :
       throw(ArgumentError("unable to coerce matrix"))
 
+(S::MatrixSpace)(n::Integer) = diagonal_matrix(S.base_ring(n), S.nrows, S.ncols)
+
 ###############################################################################
 #
 #   Matrix constructors

--- a/test/matrix/smatrix-test.jl
+++ b/test/matrix/smatrix-test.jl
@@ -32,6 +32,11 @@
    @test isa(Z2, smatrix)
    @test iszero(Z2)
 
+   D = S(3) # TODO: test more interesting matrix dimensions
+   @test D isa smatrix
+   @test D[1, 1] == 3
+   @test D[1, 2] == 0
+
    Rx, _ = PolynomialRing(QQ, ["x"])
    Z = zero_matrix(Rx, 2, 3)
    @test_throws ArgumentError S(Z)

--- a/test/matrix/smatrix-test.jl
+++ b/test/matrix/smatrix-test.jl
@@ -15,6 +15,8 @@
    @test typeof(S) <: AbstractAlgebra.Set
    @test typeof(M) <: AbstractAlgebra.SetElem
 
+   @test S(M) === M
+
    N = std(I)
    V = Singular.Matrix(N)
 
@@ -29,6 +31,10 @@
    @test iszero(Z)
    @test isa(Z2, smatrix)
    @test iszero(Z2)
+
+   Rx, _ = PolynomialRing(QQ, ["x"])
+   Z = zero_matrix(Rx, 2, 3)
+   @test_throws ArgumentError S(Z)
 end
 
 @testset "smatrix.manipulation..." begin

--- a/test/matrix/smatrix-test.jl
+++ b/test/matrix/smatrix-test.jl
@@ -37,9 +37,15 @@
    @test D[1, 1] == 3
    @test D[1, 2] == 0
 
+   D = S(x+y)
+   @test D isa smatrix
+   @test D[1, 1] == x+y
+   @test D[1, 2] == 0
+
    Rx, _ = PolynomialRing(QQ, ["x"])
    Z = zero_matrix(Rx, 2, 3)
    @test_throws ArgumentError S(Z)
+   @test_throws Exception S(Z[1, 1])
 end
 
 @testset "smatrix.manipulation..." begin

--- a/test/matrix/smatrix-test.jl
+++ b/test/matrix/smatrix-test.jl
@@ -19,12 +19,16 @@
    V = Singular.Matrix(N)
 
    Z = zero_matrix(R, 2 ,3)
+   Z2 = S()
    E = identity_matrix(R, 3)
 
    @test isa(E, smatrix)
    @test isa(M, smatrix)
    @test isa(V, smatrix)
    @test isa(Z, smatrix)
+   @test iszero(Z)
+   @test isa(Z2, smatrix)
+   @test iszero(Z2)
 end
 
 @testset "smatrix.manipulation..." begin
@@ -81,4 +85,3 @@ end
    @test M1 == M1
    @test M1 == deepcopy(M1)
 end
-


### PR DESCRIPTION
This is to follow the AbstractAlgebra API.
In the process, import `zero_matrix` from AA instead of defining a new function. 