### PR TITLE
docs: fix one error and update Documenter to 0.23

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,14 +1,14 @@
 [deps]
-Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
+Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.19"
 AbstractAlgebra = "^0.10.0"
+Documenter = "0.23"

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -41,7 +41,7 @@ this is appropriate.
 
 [https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html](https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html)
 
-Below, we describe the functionality that is specific to the Singular multivariate 
+Below, we describe the functionality that is specific to the Singular multivariate
 polynomials that is not documented in the general multivariate interface.
 
 ### Constructors
@@ -59,7 +59,7 @@ must be a list of strings corresponding to how the variables will be printed. By
 there will only be one Singular polynomial ring in the system for each combination of
 coefficient ring, list of variable names, ordering and degree bound. This is
 accomplished by making use of a global cache. If this is not the desired behaviour,
-`false` can be passed to the optional argument `cached`. 
+`false` can be passed to the optional argument `cached`.
 
 Two orderings can be specified, one for term ordering of the polynomials, and another
 for ordering of module components. They can occur in either order, the first taking
@@ -208,7 +208,7 @@ c = characteristic(R)
 L = degree_bound(R)
 exps = lead_exponent(x1*x2 + 3x1*x2^2 + x3 + 2)
 deg = total_degree(x1*x2 + 3x1*x2^2 + x3 + 2)
-ord = order(x1*x2 + 3x1*x2^2 + x3 + 2) 
+ord = order(x1*x2 + 3x1*x2^2 + x3 + 2)
 ```
 
 ### Differential functions
@@ -286,7 +286,7 @@ c = content(f)
 
 ### Multivariate Factorisation
 
-For the Singular base fields `QQ` and `Fp` a function to compute a 
+For the Singular base fields `QQ` and `Fp` a function to compute a
 squarefree factorization is available.
 
 ```@docs
@@ -325,8 +325,8 @@ It is possible to change the coefficient ring of a given polynomial $p$ via
 the function 'change_base_ring'.
 
 ```@docs
-Singular.change_base_ring(C::Union{Ring, Field} p::spoly)
-` ``
+Singular.change_base_ring(C::Union{Ring, Field}, p::spoly)
+```
 
 **Examples**
 


### PR DESCRIPTION
A comma was missing in a signature, and triple backticks had a spurious
space in between.
Documenter 0.24 and 0.25 is released, but this would require some changes
to the make.jl file.