### PR TITLE
manual: fix "no docs found for ..."

### DIFF
--- a/docs/src/ideal.md
+++ b/docs/src/ideal.md
@@ -5,7 +5,7 @@ CurrentModule = Singular
 # Ideals
 
 Singular.jl allows the creation of ideals over a Singular polynomial ring. These are
-internally stored as a list of (polynomial) generators. This list of generators can also 
+internally stored as a list of (polynomial) generators. This list of generators can also
 have the property of being a Groebner basis.
 
 The default ideal type in Singular.jl is the Singular `sideal` type.
@@ -55,7 +55,7 @@ Ideal(R::PolyRing{T}, ids::spoly{T}...) where T <: Nemo.RingElem
 Ideal(R::PolyRing{T}, ids::Array{spoly{T}, 1}) where T <: Nemo.RingElem
 ```
 
-Construct the ideal over the polynomial ring $R$ whose (polynomial) generators are given 
+Construct the ideal over the polynomial ring $R$ whose (polynomial) generators are given
 by the given parameter list or array of polynomials, respectively. The list may be
 empty, resulting in the zero ideal.
 
@@ -94,7 +94,7 @@ iszerodim(::sideal)
 ```
 
 ```@docs
-dimension(::sideal)
+dimension(I::sideal{S}) where S <: Union{spoly{T}, spoly{n_unknown{U}}} where {T <: Singular.FieldElem, U <: Nemo.FieldElem}
 ```
 
 ```@docs
@@ -245,7 +245,7 @@ std(::sideal; ::Bool)
 ```
 
 ```@docs
-fglm(::sideal; ::Symbol)
+fglm(::sideal, ::Symbol)
 ```
 
 ```@docs
@@ -439,11 +439,11 @@ If an arbitrary ideal $I$ is passed to the function, the computation is performe
 the leading ideal of $I$.
 
 ```@docs
-independent_sets(::sideal)
+independent_sets(I::sideal{S}) where S <: Union{spoly{T}, spoly{n_unknown{U}}} where {T <: Singular.FieldElem, U <: Nemo.FieldElem}
 ```
 
 ```@docs
-maximal_independent_set(::sideal; ::Bool)
+maximal_independent_set(I::sideal{S}; all::Bool = false) where S <: Union{spoly{T}, spoly{n_unknown{U}}} where {T <: Singular.FieldElem, U <: Nemo.FieldElem}
 ```
 
 ```julia

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -55,6 +55,11 @@ function setindex!(M::smatrix, p::spoly, i::Int, j::Int)
    libSingular.setindex(M.ptr, p.ptr, Cint(i), Cint(j), R.ptr)
 end
 
+"""
+    iszero(M::smatrix)
+
+Return whether the supplied matrix `M` is the zero matrix.
+"""
 function iszero(M::smatrix)
    for i = 1:nrows(M)
       for j = 1:ncols(M)
@@ -94,7 +99,7 @@ end
 
 ###############################################################################
 #
-#   String I/O 
+#   String I/O
 #
 ###############################################################################
 


### PR DESCRIPTION
This makes running `docs/make.jl` clean, with only a `Warning: 17 docstrings potentially missing:` message (which we could suppress with an option).