### PR TITLE
Tweak GitHub Actions config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,15 +6,23 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.3', '1.4', '1.5', 'nightly']
-        julia-arch: [x64]
-        os: [ubuntu-latest, macOS-latest]
+        julia-version:
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - 'nightly'
+        julia-arch:
+          - x64
+        os:
+          - ubuntu-latest
+          - macOS-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
@@ -32,9 +40,9 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@master
+        uses: julia-actions/julia-buildpkg@latest
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@master
+        uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
@@ -77,9 +85,9 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@master
+        uses: julia-actions/julia-buildpkg@latest
       - run: |
-          julia --project=docs -e '
+          julia --project=docs --color=yes -e '
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
@@ -88,7 +96,7 @@ jobs:
             using Documenter: doctest
             using Singular
             doctest(Singular)'
-      - run: julia --project=docs docs/make.jl
+      - run: julia --project=docs --color=yes docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
- allow errors with Julia nightly, so that they don't cause the CI
  status to be marked as fail
- use actions/checkout@v2 instead of v1 (may fix issues with coverage)
- put lists of julia versions, target OSes on separate lines, to make
  diffs here in the future smaller
- use "latest" tag of actions, not master (slightly more stable)
- enable color output for documentation build steps