### PR TITLE
Update to latest Singular_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "Singular"
 uuid = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
-version = "0.4.2"
+version = "0.4.2-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -18,14 +17,13 @@ lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 libsingular_julia_jll = "ae4fbd8f-ecdb-54f8-bbce-35570499b30e"
 
 [compat]
-AbstractAlgebra = "^0.10, 0.11, 0.12"
-BinaryProvider = "^0.5.8"
-CxxWrap = "0.10.1, 0.11"
-Nemo = "^0.18.1"
+AbstractAlgebra = "0.12"
+CxxWrap = "0.11"
+Nemo = "0.19"
 RandomExtensions = "0.4.2"
-Singular_jll = "~4.1.3"
+Singular_jll = "~402.000"
 julia = "1.3"
-libsingular_julia_jll = "~0.2.0"
+libsingular_julia_jll = "~0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,5 +10,4 @@ Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-AbstractAlgebra = "^0.10.0"
 Documenter = "0.26"

--- a/test/caller-test.jl
+++ b/test/caller-test.jl
@@ -14,23 +14,23 @@
 
     R, (x,y,z) = PolynomialRing(Singular.QQ, ["x", "y", "z"])
     
-    i1 = Singular.LibPoly.cyclic(R, 3)
+    i1 = Singular.LibPolylib.cyclic(R, 3)
     i2 = Ideal( R, x+y+z, x*y+x*z+y*z, x*y*z-1 )
     @test equal(i1, i2)
 
     vec = FreeModule(R,2)([x,y])
     mod = Singular.Module(R, vec)
-    i1 = Singular.LibPoly.mod2id(R,mod,[1,2])
+    i1 = Singular.LibPolylib.mod2id(R,mod,[1,2])
     i2 = Ideal(R, x^2, x*y, y^2, x^2 )
     @test equal(i1, i2)
 
     i1 = Ideal(R, x, y)
     i2 = Ideal(R, x^2, x*y, y^2, x, y)
-    mod = Singular.LibPoly.id2mod(R, i1, [1,2])
-    i1 = Singular.LibPoly.mod2id(R, mod, [1,2])
+    mod = Singular.LibPolylib.id2mod(R, i1, [1,2])
+    i1 = Singular.LibPolylib.mod2id(R, mod, [1,2])
     @test equal(i1,i2)
-    @test Singular.LibPoly.content(R,vec) == 1
-    @test Singular.LibPoly.lcm(R,x) == x
+    @test Singular.LibPolylib.content(R,vec) == 1
+    @test Singular.LibPolylib.lcm(R,x) == x
 
     i1 = Ideal(R, x*z, y*z, x^3-y^3)
     @test Singular.LibStandard.res(R,i1,0) isa Singular.sresolution


### PR DESCRIPTION
This also requires updating libsingular_julia_jll and Nemo, which
in turn means we can just as well stop pretending that older versions
of AbstractAlgebra are still supported.

Also get rid of a stale dependency on BinaryProvider.

Fixes #274
Fixes #294
Closes #320