### PR TITLE
Expressify the number types

### DIFF
--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -106,6 +106,10 @@ function show(io::IO, c::Rationals)
    print(io, "Rational Field")
 end
 
+function AbstractAlgebra.expressify(n::n_Q; context = nothing)::Any
+  return AbstractAlgebra.expressify(Rational{BigInt}(n), context = context)
+end
+
 function show(io::IO, n::n_Q)
     libSingular.StringSetS("")
 

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -102,6 +102,10 @@ function show(io::IO, c::Integers)
    print(io, "Integer Ring")
 end
 
+function AbstractAlgebra.expressify(n::n_Z; context = nothing)::Any
+  return AbstractAlgebra.expressify(BigInt(n), context = context)
+end
+
 function show(io::IO, n::n_Z)
    libSingular.StringSetS("")
 

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -89,6 +89,18 @@ function show(io::IO, c::N_ZnRing)
    print(io, "Residue Ring of Integer Ring modulo ", characteristic(c))
 end
 
+function Base.show(io::IO, ::MIME"text/plain", a::n_Zn)
+  print(io, AbstractAlgebra.obj_to_string(a, context = io))
+end
+
+function AbstractAlgebra.expressify(n::n_Zn; context = nothing)::Any
+  x = BigInt()
+  GC.@preserve n begin
+    ccall((:__gmpz_set, :libgmp), Cvoid, (Ref{BigInt},  Ptr{Any}), x, n.ptr.cpp_object)
+  end
+  return AbstractAlgebra.expressify(x, context = context)
+end
+
 function show(io::IO, n::n_Zn)
    libSingular.StringSetS("")
    libSingular.n_Write(n.ptr, parent(n).ptr, false)

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -80,6 +80,28 @@ function show(io::IO, c::N_ZpField)
    print(io, "Finite Field of Characteristic ", characteristic(c))
 end
 
+function Base.show(io::IO, ::MIME"text/plain", a::n_Zp)
+  println("here")
+  print(io, AbstractAlgebra.obj_to_string(a, context = io))
+end
+
+if VERSION >= v"1.5"
+  function AbstractAlgebra.expressify(n::n_Zp; context = nothing)::Any
+    nn = rem(Int(n), Int(characteristic(parent(n))), RoundNearest)
+    return AbstractAlgebra.expressify(nn, context = context)
+  end
+else
+  function AbstractAlgebra.expressify(n::n_Zp; context = nothing)::Any
+    p = Int(characteristic(parent(n)))
+    nn = Int(n)
+    if 2*nn > p
+      nn = nn - p
+    end
+
+    return AbstractAlgebra.expressify(nn, context = context)
+  end
+end
+
 function show(io::IO, n::n_Zp)
    libSingular.StringSetS("")
    libSingular.n_Write(n.ptr, parent(n).ptr, false)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -362,6 +362,12 @@ function show(io::IO, a::spoly)
    print(io, s)
 end
 
+# TODO: Remove this once we can properly expressify elements of type n_GF
+function show(io::IO, ::MIME"text/plain", a::spoly{n_GF})
+   s = libSingular.p_String(a.ptr, parent(a).ptr)
+   print(io, s)
+end
+
 show_minus_one(::Type{spoly{T}}) where T <: Nemo.RingElem = show_minus_one(T)
 
 needs_parentheses(x::spoly) = length(x) > 1

--- a/test/number/n_Q-test.jl
+++ b/test/number/n_Q-test.jl
@@ -65,6 +65,7 @@ end
 
 @testset "n_Q.printing..." begin
    @test string(QQ(123)) == "123"
+   @test sprint(show, "text/plain", (QQ(123))) == "123"
 end
 
 @testset "n_Q.manipulation..." begin

--- a/test/number/n_Z-test.jl
+++ b/test/number/n_Z-test.jl
@@ -37,6 +37,7 @@ end
 
 @testset "n_Z.printing..." begin
    @test string(ZZ(123)) == "123"
+   @test sprint(show, "text/plain", (ZZ(123))) == "123"
 end
 
 @testset "n_Z.manipulation..." begin

--- a/test/number/n_Zn-test.jl
+++ b/test/number/n_Zn-test.jl
@@ -40,6 +40,8 @@ end
    R = ResidueRing(ZZ, 5)
 
    @test string(R(3)) == "3"
+
+   @test sprint(show, "text/plain", (R(3))) == "3"
 end
 
 @testset "n_Zn.manipulation..." begin

--- a/test/number/n_Zp-test.jl
+++ b/test/number/n_Zp-test.jl
@@ -40,6 +40,8 @@ end
    R = Fp(5)
 
    @test string(R(3)) == "-2"
+
+   @test sprint(show, "text/plain", R(3)) == "-2"
 end
 
 @testset "n_Zp.manipulation..." begin

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -87,6 +87,22 @@ end
    R, (x, ) = PolynomialRing(ZZ, ["x", ])
 
    @test length(string(3x^2 + 2x + 1)) > 3
+   @test length(sprint(show, "text/plain", 3x^2 + 2x + 1)) > 3
+
+   R, (x, ) = PolynomialRing(QQ, ["x", ])
+
+   @test length(string(3x^2 + 2x + 1)) > 3
+   @test length(sprint(show, "text/plain", 3x^2 + 2x + 1)) > 3
+
+   R, (x, ) = PolynomialRing(Fp(5), ["x", ])
+
+   @test length(string(3x^2 + 2x + 1)) > 3
+   @test length(sprint(show, "text/plain", 3x^2 + 2x + 1)) > 3
+
+   R, (x, ) = PolynomialRing(ResidueRing(ZZ, 5), ["x", ])
+
+   @test length(string(3x^2 + 2x + 1)) > 3
+   @test length(sprint(show, "text/plain", 3x^2 + 2x + 1)) > 3
 end
 
 @testset "spoly.manipulation..." begin


### PR DESCRIPTION
Fixes #322.

@tthsqe12: The polynomial printing is picking up our `show(io::IO, ::MIME{Symbol("text/plain")}, a::AbstractAlgebra.MPolyElem)` defined in AbstractAlgebra. So I think the best is to just define expressify for the Singular.jl number types. I did it already for `n_Z` and `n_Q` (which fixes #322).

I would also like to add it to `n_Zn`, `n_Zp` and `n_GF`. For the first two it would be the best if we could convert the vaules to `Int/BigInt`. Do you know if this is possible?