### PR TITLE
define AbstractAlgebra.expressify on n_GF

### DIFF
--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -309,6 +309,7 @@ mutable struct N_GField <: Field
    from_n_Z::Ptr{Nothing}
    to_n_Z::Ptr{Nothing}
    refcount::Int
+   S::Symbol
 
    function N_GField(p::Int, n::Int, S::Symbol) 
       if haskey(N_GFieldID, (p, n, S))
@@ -318,7 +319,7 @@ mutable struct N_GField <: Field
          GC.@preserve gfinfo begin
          ptr = libSingular.nInitChar(libSingular.n_GF, pointer_from_objref(gfinfo))
          d = new(ptr, n, libSingular.n_SetMap(ZZ.ptr, ptr), 
-              libSingular.n_SetMap(ptr, ZZ.ptr), 1)
+              libSingular.n_SetMap(ptr, ZZ.ptr), 1, S)
          end
          N_GFieldID[p, n, S] = d
          finalizer(_N_GField_clear_fn, d)

--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -93,19 +93,34 @@ function show(io::IO, c::N_GField)
    print(io, "Finite Field of Characteristic ", characteristic(c), " and degree ", degree(c))
 end
 
+function Base.show(io::IO, ::MIME"text/plain", a::n_GF)
+  print(io, AbstractAlgebra.obj_to_string(a, context = io))
+end
+
+function AbstractAlgebra.expressify(a::n_GF; context = nothing)::Any
+  F = parent(a)
+  i = reinterpret(Int, a.ptr.cpp_object)
+  if 1 < i < characteristic(F)^degree(F)
+    return Expr(:call, :^, F.S, i)
+  elseif i == 1
+    return F.S
+  elseif i == 0
+    return 1
+  else
+    return 0
+  end
+end
+
 function show(io::IO, n::n_GF)
    libSingular.StringSetS("")
-
    libSingular.n_Write(n.ptr, parent(n).ptr, false)
-
    m = libSingular.StringEndS()
-   
    print(io, m)
 end
 
 needs_parentheses(x::n_GF) = false
 
-isnegative(x::n_GF) = x == -1
+isnegative(x::n_GF) = false
 
 show_minus_one(::Type{n_GF}) = false
 

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -81,7 +81,6 @@ function show(io::IO, c::N_ZpField)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", a::n_Zp)
-  println("here")
   print(io, AbstractAlgebra.obj_to_string(a, context = io))
 end
 

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -362,12 +362,6 @@ function show(io::IO, a::spoly)
    print(io, s)
 end
 
-# TODO: Remove this once we can properly expressify elements of type n_GF
-function show(io::IO, ::MIME"text/plain", a::spoly{n_GF})
-   s = libSingular.p_String(a.ptr, parent(a).ptr)
-   print(io, s)
-end
-
 show_minus_one(::Type{spoly{T}}) where T <: Nemo.RingElem = show_minus_one(T)
 
 needs_parentheses(x::spoly) = length(x) > 1

--- a/test/number/n_GF-test.jl
+++ b/test/number/n_GF-test.jl
@@ -42,7 +42,20 @@ end
 @testset "n_GF.printing..." begin
    R, x = FiniteField(5, 2, "x")
 
-   @test string(3x + 2) == "x^11"
+   @test string(zero(R)) == "0"
+   @test string(one(R)) == "1"
+   @test string(x) == "x"
+   @test string(x^2) == "x^2"
+   @test string(x^11) == "x^11"
+
+   @test sprint(show, "text/plain", zero(R)) == "0"
+   @test sprint(show, "text/plain", one(R)) == "1"
+   @test sprint(show, "text/plain", x) == "x"
+   @test sprint(show, "text/plain", x^2) == "x^2"
+   @test sprint(show, "text/plain", x^11) == "x^11"
+
+   @test !Singular.AbstractAlgebra.isnegative(x)
+   @test !Singular.AbstractAlgebra.needs_parentheses(x)
 end
 
 @testset "n_GF.manipulation..." begin

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -103,6 +103,9 @@ end
 
    @test length(string(3x^2 + 2x + 1)) > 3
    @test length(sprint(show, "text/plain", 3x^2 + 2x + 1)) > 3
+
+   R, (x, ) = PolynomialRing(FiniteField(5, 3, "a")[1], ["x", ])
+   @test string(x) == "x"
 end
 
 @testset "spoly.manipulation..." begin


### PR DESCRIPTION
Singular.jl should now play nice with AbstractAlgebra.expressify with regards to n_GF. This means that polynomials over GF print nicely.
```
julia> F,a=FiniteField(5,3,"a")
(Finite Field of Characteristic 5 and degree 3, a)

julia> R,(x,y,z)=PolynomialRing(F,["x", "y", "z"])
(Singular Polynomial Ring (125,a),(x,y,z),(dp(3),C), spoly{n_GF}[x, y, z])

julia> (x+a*y-z)^2+a
x^2 + a^32*x*y + a^2*y^2 + a^93*x*z + a^94*y*z + z^2 + a

julia> Singular.AbstractAlgebra.expressify(ans)
:(1 * x ^ 2 + a ^ 32 * x * y + a ^ 2 * y ^ 2 + a ^ 93 * x * z + a ^ 94 * y * z + 1 * z ^ 2 + (*)(a))

julia> Singular.AbstractAlgebra.canonicalize(ans)
:(x ^ 2 + a ^ 32 * x * y + a ^ 2 * y ^ 2 + a ^ 93 * x * z + a ^ 94 * y * z + z ^ 2 + a)

```