### PR TITLE
Reduce number of inner constructors

### DIFF
--- a/src/matrix/MatrixTypes.jl
+++ b/src/matrix/MatrixTypes.jl
@@ -24,20 +24,18 @@ mutable struct smatrix{T <: Nemo.RingElem} <: Nemo.SetElem
    ptr::libSingular.matrix_ptr
    base_ring::PolyRing
 
-   # really takes a Singular module, which has type ideal
-   function smatrix{T}(R::PolyRing, m::libSingular.ideal_ptr) where T
-      ptr = libSingular.id_Copy(m, R.ptr)
-      ptr = libSingular.id_Module2Matrix(ptr, R.ptr)
-      z = new(ptr, R)
-      finalizer(_smatrix_clear_fn, z)
-      return z
-   end
-
    function smatrix{T}(R::PolyRing, ptr::libSingular.matrix_ptr) where {T}
       z = new(ptr, R)
       finalizer(_smatrix_clear_fn, z)
       return z
    end
+end
+
+# really takes a Singular module, which has type ideal
+function smatrix{T}(R::PolyRing, m::libSingular.ideal_ptr) where T
+   ptr = libSingular.id_Copy(m, R.ptr)
+   ptr = libSingular.id_Module2Matrix(ptr, R.ptr)
+   return smatrix{T}(R, ptr)
 end
 
 function _smatrix_clear_fn(I::smatrix)

--- a/src/module/ModuleTypes.jl
+++ b/src/module/ModuleTypes.jl
@@ -41,7 +41,7 @@ This needs to be indicated due to the fact that Singulars
 vectors and polys are both stored in the poly data structure.
 """
 function (R::PolyRing{T})(m::libSingular.poly_ptr, ::Val{:vector}) where T
-    return svector{T}(R, 1, m)
+   return svector{T}(R, 1, m)
 end
 
 function _svector_clear_fn(p::svector)
@@ -75,39 +75,33 @@ mutable struct smodule{T <: Nemo.RingElem} <: Module{T}
    base_ring::PolyRing
    isGB::Bool
 
-   function smodule{T}(R::PolyRing, vecs::svector...) where T
-      n = length(vecs)
-      r = vecs[1].rank;
-      for i = 1:n
-         @assert vecs[i].rank == r
-      end
-      m = libSingular.idInit(Cint(n), Cint(r))
-      z = new(m, R, false)
-      R.refcount += 1
-      finalizer(_smodule_clear_fn, z)
-      for i = 1:n
-         v = libSingular.p_Copy(vecs[i].ptr, R.ptr)
-         libSingular.setindex_internal(m, v, Cint(i - 1))
-      end
-      return z
-   end
-
    function smodule{T}(R::PolyRing, m::libSingular.ideal_ptr) where T
       z = new(m, R, false)
       R.refcount += 1
       finalizer(_smodule_clear_fn, z)
       return z
    end
+end
 
-   function smodule{T}(R::PolyRing, m::libSingular.matrix_ptr) where T
-      ptr = libSingular.mp_Copy(m, R.ptr)
-      ptr = libSingular.id_Matrix2Module(ptr, R.ptr)
-      z = new(ptr, R)
-      R.refcount += 1
-      finalizer(_smodule_clear_fn, z)
-      return z
+function smodule{T}(R::PolyRing, m::libSingular.matrix_ptr) where T
+   ptr = libSingular.mp_Copy(m, R.ptr)
+   ptr = libSingular.id_Matrix2Module(ptr, R.ptr)
+   return smodule{T}(R, ptr)
+end
+
+function smodule{T}(R::PolyRing, vecs::svector...) where T
+   n = length(vecs)
+   r = vecs[1].rank;
+   for i = 1:n
+      @assert vecs[i].rank == r
    end
-
+   m = libSingular.idInit(Cint(n), Cint(r))
+   z = smodule{T}(R, m)
+   for i = 1:n
+      v = libSingular.p_Copy(vecs[i].ptr, R.ptr)
+      libSingular.setindex_internal(m, v, Cint(i - 1))
+   end
+   return z
 end
 
 """
@@ -119,7 +113,7 @@ This needs to be indicated due to the fact that Singular's
 modules and ideals are both stored in the ideal data structure.
 """
 function (R::PolyRing{T})(m::libSingular.ideal_ptr, ::Val{:module}) where T
-    return smodule{T}(R,m)
+   return smodule{T}(R,m)
 end
 
 function _smodule_clear_fn(I::smodule)

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -35,22 +35,6 @@ end
 mutable struct n_Z <: Nemo.RingElem
     ptr::libSingular.number_ptr
 
-    function n_Z()
-        c = ZZ.ptr
-        z = new(libSingular.n_Init(0, c))
-        parent(z).refcount += 1
-        finalizer(_n_Z_clear_fn, z)
-        return z
-    end
-
-    function n_Z(n::Int)
-        c = ZZ.ptr
-        z = new(libSingular.n_Init(n, c))
-        parent(z).refcount += 1
-        finalizer(_n_Z_clear_fn, z)
-        return z
-    end
-
     function n_Z(n::libSingular.number_ptr)
         z = new(n)
         parent(z).refcount += 1
@@ -58,6 +42,8 @@ mutable struct n_Z <: Nemo.RingElem
         return z
     end
 end
+
+n_Z(n::Int = 0) = n_Z(libSingular.n_Init(n, ZZ.ptr))
 
 function _n_Z_clear_fn(n::n_Z)
    R = parent(n)
@@ -102,29 +88,6 @@ end
 mutable struct n_Q <: Nemo.FieldElem
     ptr::libSingular.number_ptr
 
-    function n_Q()
-        c = QQ.ptr
-        z = new(libSingular.n_Init(0, c))
-        parent(z).refcount += 1
-        finalizer(_n_Q_clear_fn, z)
-        return z
-    end
-
-    function n_Q(n::Int)
-        c = QQ.ptr
-        z = new(libSingular.n_Init(n, c))
-        parent(z).refcount += 1
-        finalizer(_n_Q_clear_fn, z)
-        return z
-    end
-
-    function n_Q(n::n_Z)
-        z = new(libSingular.nApplyMapFunc(n_Z_2_n_Q, n.ptr, ZZ.ptr, QQ.ptr))
-        parent(z).refcount += 1
-        finalizer(_n_Q_clear_fn, z)
-        return z
-    end
-
     function n_Q(n::libSingular.number_ptr)
         z = new(n)
         parent(z).refcount += 1
@@ -132,6 +95,9 @@ mutable struct n_Q <: Nemo.FieldElem
         return z
     end
 end
+
+n_Q(n::Int = 0) = n_Q(libSingular.n_Init(n, QQ.ptr))
+n_Q(n::n_Z) = n_Q(libSingular.nApplyMapFunc(n_Z_2_n_Q, n.ptr, ZZ.ptr, QQ.ptr))
 
 function _n_Q_clear_fn(n::n_Q)
    R = parent(n)
@@ -186,20 +152,6 @@ mutable struct n_Zn <: Nemo.RingElem
     ptr::libSingular.number_ptr
     parent::N_ZnRing
 
-    function n_Zn(c::N_ZnRing)
-    	z = new(libSingular.n_Init(0, c.ptr))
-        c.refcount += 1
-        finalizer(_n_Zn_clear_fn, z)
-        return z
-    end
-
-    function n_Zn(c::N_ZnRing, n::Int)
-    	z = new(libSingular.n_Init(n, c.ptr))
-        c.refcount += 1
-        finalizer(_n_Zn_clear_fn, z)
-        return z
-    end
-
     function n_Zn(c::N_ZnRing, n::libSingular.number_ptr)
     	z = new(n)
         c.refcount += 1
@@ -207,6 +159,8 @@ mutable struct n_Zn <: Nemo.RingElem
         return z
     end
 end
+
+n_Zn(c::N_ZnRing, n::Int = 0) = n_Zn(c, libSingular.n_Init(n, c.ptr))
 
 function _n_Zn_clear_fn(n::n_Zn)
    R = parent(n)
@@ -258,20 +212,6 @@ mutable struct n_Zp <: Nemo.FieldElem
     ptr::libSingular.number_ptr
     parent::N_ZpField
 
-    function n_Zp(c::N_ZpField)
-    	z = new(libSingular.n_Init(0, c.ptr))
-        c.refcount += 1
-        finalizer(_n_Zp_clear_fn, z)
-        return z
-    end
-
-    function n_Zp(c::N_ZpField, n::Int)
-    	z = new(libSingular.n_Init(n, c.ptr))
-        c.refcount += 1
-        finalizer(_n_Zp_clear_fn, z)
-        return z
-    end
-
     function n_Zp(c::N_ZpField, n::libSingular.number_ptr)
     	z = new(n)
         c.refcount += 1
@@ -279,6 +219,8 @@ mutable struct n_Zp <: Nemo.FieldElem
         return z
     end
 end
+
+n_Zp(c::N_ZpField, n::Int = 0) = n_Zp(c, libSingular.n_Init(n, c.ptr))
 
 function _n_Zp_clear_fn(n::n_Zp)
    R = parent(n)
@@ -339,20 +281,6 @@ mutable struct n_GF <: Nemo.FieldElem
     ptr::libSingular.number_ptr
     parent::N_GField
 
-    function n_GF(c::N_GField)
-    	z = new(libSingular.n_Init(0, c.ptr))
-        c.refcount += 1
-        finalizer(_n_GF_clear_fn, z)
-        return z
-    end
-
-    function n_GF(c::N_GField, n::Int)
-    	z = new(libSingular.n_Init(n, c.ptr))
-        c.refcount += 1
-        finalizer(_n_GF_clear_fn, z)
-        return z
-    end
-
     function n_GF(c::N_GField, n::libSingular.number_ptr)
     	z = new(n)
         c.refcount += 1
@@ -360,6 +288,8 @@ mutable struct n_GF <: Nemo.FieldElem
         return z
     end
 end
+
+n_GF(c::N_GField, n::Int = 0) = n_GF(c, libSingular.n_Init(n, c.ptr))
 
 function _n_GF_clear_fn(n::n_GF)
    R = parent(n)
@@ -407,20 +337,6 @@ mutable struct n_transExt <: Nemo.FieldElem
     ptr::libSingular.number_ptr
     parent::N_FField
 
-    function n_transExt(c::N_FField)
-    	z = new(libSingular.n_Init(0, c.ptr))
-        c.refcount += 1
-        finalizer(_n_transExt_clear_fn, z)
-        return z
-    end
-
-    function n_transExt(c::N_FField, n::Int)
-    	z = new(libSingular.n_Init(n, c.ptr))
-        c.refcount += 1
-        finalizer(_n_transExt_clear_fn, z)
-        return z
-    end
-
     function n_transExt(c::N_FField, n::libSingular.number_ptr)
     	z = new(n)
         c.refcount += 1
@@ -428,6 +344,8 @@ mutable struct n_transExt <: Nemo.FieldElem
         return z
     end
 end
+
+n_transExt(c::N_FField, n::Int = 0) = n_transExt(c, libSingular.n_Init(n, c.ptr))
 
 function _n_transExt_clear_fn(n::n_transExt)
    R = parent(n)

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -64,10 +64,10 @@ mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
 end
 
 function (R::PolyRing{T})(r::libSingular.ring_ptr) where T
-    new_r = deepcopy(R)
-    new_ptr = new_r.ptr
-    new_r.ptr = r
-    return new_r
+   new_r = deepcopy(R)
+   new_ptr = new_r.ptr
+   new_r.ptr = r
+   return new_r
 end
 
 function _PolyRing_clear_fn(R::PolyRing)
@@ -81,64 +81,47 @@ mutable struct spoly{T <: Nemo.RingElem} <: Nemo.MPolyElem{T}
    ptr::libSingular.poly_ptr
    parent::PolyRing{T}
 
-   function spoly{T}(R::PolyRing{T}) where T <: Nemo.RingElem
-      p = libSingular.p_ISet(0, R.ptr)
-      z = new{T}(p, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
-    
    function spoly{T}(R::PolyRing{T}, p::libSingular.poly_ptr) where T <: Nemo.RingElem
       z = new{T}(p, R)
       R.refcount += 1
       finalizer(_spoly_clear_fn, z)
       return z
    end
-    
-   function spoly{T}(R::PolyRing{T}, p::T) where T <: Nemo.RingElem
-      n = libSingular.n_Copy(p.ptr, parent(p).ptr)
-      r = libSingular.p_NSet(n, R.ptr)
-      z = new{T}(r, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
-    
-   function spoly{T}(R::PolyRing{T}, n::libSingular.number_ptr) where T <: Nemo.RingElem
-      nn = libSingular.n_Copy(n, base_ring(R).ptr)
-      p = libSingular.p_NSet(nn, R.ptr)
-      z = new{T}(p, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
-
-   function spoly{T}(R::PolyRing{T}, n::Ptr{Cvoid}) where T <: Nemo.RingElem
-      p = libSingular.p_NSet(n, R.ptr)
-      z = new(p, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
-
-   function spoly{T}(R::PolyRing{T}, b::Int) where T <: Nemo.RingElem
-      p = libSingular.p_ISet(b, R.ptr)
-      z = new{T}(p, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
-
-   function spoly{T}(R::PolyRing{T}, b::BigInt) where T <: Nemo.RingElem
-      n = libSingular.n_InitMPZ(b, R.base_ring.ptr)
-      p = libSingular.p_NSet(n, R.ptr)
-      z = new{T}(p, R)
-      R.refcount += 1
-      finalizer(_spoly_clear_fn, z)
-      return z
-   end
 end
+
+function spoly{T}(R::PolyRing{T}) where T <: Nemo.RingElem
+   p = libSingular.p_ISet(0, R.ptr)
+   return spoly{T}(R, p)
+end
+
+function spoly{T}(R::PolyRing{T}, p::T) where T <: Nemo.RingElem
+   n = libSingular.n_Copy(p.ptr, parent(p).ptr)
+   r = libSingular.p_NSet(n, R.ptr)
+   return spoly{T}(R, r)
+end
+
+function spoly{T}(R::PolyRing{T}, n::libSingular.number_ptr) where T <: Nemo.RingElem
+   nn = libSingular.n_Copy(n, base_ring(R).ptr)
+   p = libSingular.p_NSet(nn, R.ptr)
+   return spoly{T}(R, p)
+end
+
+function spoly{T}(R::PolyRing{T}, n::Ptr{Cvoid}) where T <: Nemo.RingElem
+   p = libSingular.p_NSet(n, R.ptr)
+   return spoly{T}(R, p)
+end
+
+function spoly{T}(R::PolyRing{T}, b::Int) where T <: Nemo.RingElem
+   p = libSingular.p_ISet(b, R.ptr)
+   return spoly{T}(R, p)
+end
+
+function spoly{T}(R::PolyRing{T}, b::BigInt) where T <: Nemo.RingElem
+   n = libSingular.n_InitMPZ(b, R.base_ring.ptr)
+   p = libSingular.p_NSet(n, R.ptr)
+   return spoly{T}(R, p)
+end
+
 
 function _spoly_clear_fn(p::spoly)
    R = parent(p)


### PR DESCRIPTION
Best practice in Julia is to have as few inner constructors as possible, which
are primarily there to enforce invariants (in our case: to update ring
refcounts and set finalizers). The other constructors then can be implemented
as outer constructors which delegate to the remaining inner ones. This reduces
code duplication.