### PR TITLE
creating rings from the rings that singular creates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ Nemo = "0.19"
 RandomExtensions = "0.4.2"
 Singular_jll = "~402.000"
 julia = "1.3"
-libsingular_julia_jll = "~0.4"
+libsingular_julia_jll = "~0.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Number.jl
+++ b/src/Number.jl
@@ -13,3 +13,5 @@ include("number/n_GF.jl")
 include("number/n_transExt.jl")
 
 include("number/n_unknown.jl")
+
+include("number/n_unknownsingularcoefficient.jl")

--- a/src/caller.jl
+++ b/src/caller.jl
@@ -49,6 +49,32 @@ function convert_ring_content(value_list, rng)
     return return_dict
 end
 
+function create_ring_from_singular_ring(r::libSingular.ring_ptr)
+   ordering = libSingular.ring_ordering_as_symbol(r)
+   c = libSingular.rCoeffPtr(r)
+   if libSingular.nCoeff_is_Q(c)
+      return PolyRing{n_Q}(r, QQ, ordering)
+   elseif libSingular.nCoeff_is_Zp(c)
+      p = Int(libSingular.n_GetChar(c))
+      return PolyRing{n_Zp}(r, N_ZpField(p), ordering)
+   elseif libSingular.nCoeff_is_GF(c)
+      p = Int(libSingular.n_GetChar(c))
+      q = Int(libSingular.nfCharQ(c))
+      d = round(Int, log(p, q))
+      s = Symbol(libSingular.n_ParameterName(0, c))
+      return PolyRing{n_GF}(r, N_GField(p, d, s), ordering)
+   elseif libSingular.nCoeff_is_transExt(c)
+      p = Int(libSingular.n_GetChar(c))
+      S = [Symbol(libSingular.n_ParameterName(i-1, c)) for i in 1:
+                                           libSingular.n_NumberOfParameters(c)]
+      F = N_FField(iszero(p) ? QQ : N_ZpField(p), S)
+      return PolyRing{n_transExt}(r, F, ordering)
+   else
+      basering = N_UnknownSingularCoefficientRing(libSingular.nCopyCoeff(c))
+      return PolyRing{n_unknownsingularcoefficient}(r, basering, ordering)
+   end
+end
+
 # Converts a single return value back to Julia, i.e.,
 # a single lvar, not a linked list of such.
 function convert_return_value(single_value, rng = nothing)
@@ -58,8 +84,8 @@ function convert_return_value(single_value, rng = nothing)
     cast = casting_functions[single_value[3]][1](single_value[2])
     if cast isa Array{Any}
         return recursive_translate(cast, rng)
-    elseif cast isa libSingular.ring
-        new_ring = rng(cast)
+    elseif cast isa CxxWrap.CxxWrapCore.CxxPtr{Singular.libSingular.ring}
+        new_ring = create_ring_from_singular_ring(cast)
         return [new_ring, convert_ring_content(libSingular.get_ring_content(cast), new_ring)]
     elseif casting_functions[single_value[3]][2]
         if length(casting_functions[single_value[3]][3]) > 0

--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -54,3 +54,15 @@ function p_ExtGcd(a::poly_ptr, b::poly_ptr, res::Ptr{poly_ptr}, s::Ptr{poly_ptr}
     rp = reinterpret(Ptr{Nothing},res)
     return p_ExtGcd_internal(a, b, rp, sp, tp, r)
 end
+
+function ring_ordering_as_symbol(r::ring_ptr)
+   if Bool(rRing_ord_pure_dp(r))
+      return :degrevlex
+   elseif Bool(rRing_ord_pure_Dp(r))
+      return :deglex
+   elseif Bool(rRing_ord_pure_lp(r))
+      return :lex
+   else
+      return :unknown
+   end
+end

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -19,7 +19,6 @@ function _Elem_finalizer(n)
    nothing
 end
 
-
 ###############################################################################
 #
 #   Integers/n_Z
@@ -323,3 +322,34 @@ mutable struct n_unknown{T <: Nemo.RingElem} <: Nemo.RingElem
    parent::CoefficientRing{T}
 
 end
+
+###############################################################################
+#
+#   N_UnknownSingularCoefficientRing
+#   singular coefficient rings with no identifiable julia object
+#
+###############################################################################
+
+mutable struct N_UnknownSingularCoefficientRing <: Ring
+   ptr::libSingular.coeffs_ptr
+   refcount::Int
+
+   # take ownership of the pointer
+   function N_UnknownSingularCoefficientRing(ptr::libSingular.coeffs_ptr)
+      a = new(ptr, 1)
+      finalizer(_Ring_finalizer, a)
+      return a
+   end
+end
+
+mutable struct n_unknownsingularcoefficient <: Nemo.RingElem
+   ptr::libSingular.number_ptr
+   parent::N_UnknownSingularCoefficientRing
+
+   function n_unknownsingularcoefficient(R::N_UnknownSingularCoefficientRing, n::libSingular.number_ptr)
+      a = new(n, R)
+      finalizer(_Elem_finalizer, a)
+      return a
+   end
+end
+

--- a/src/number/n_unknownsingularcoefficient.jl
+++ b/src/number/n_unknownsingularcoefficient.jl
@@ -1,0 +1,179 @@
+###############################################################################
+#
+#   Data type and parent methods
+#
+###############################################################################
+
+elem_type(::Type{N_UnknownSingularCoefficientRing}) = n_unknownsingularcoefficient
+
+parent(a::n_unknownsingularcoefficient) = a.parent
+
+parent_type(::Type{n_unknownsingularcoefficient}) = N_UnknownSingularCoefficientRing
+
+base_ring(a::n_unknownsingularcoefficient) = Union{}
+
+base_ring(R::N_UnknownSingularCoefficientRing) = Union{}
+
+function characteristic(R::N_UnknownSingularCoefficientRing)
+   return ZZ(_characteristic(R))
+end
+
+_characteristic(R::N_UnknownSingularCoefficientRing) = Int(libSingular.n_GetChar(R.ptr))
+
+function check_parent(a::n_unknownsingularcoefficient, b::n_unknownsingularcoefficient)
+   parent(a) != parent(b) && error("Incompatible parents")
+end
+
+###############################################################################
+#
+#   Basic manipulation
+#
+###############################################################################
+
+function canonical_unit(a::n_unknownsingularcoefficient)
+   error("canonical_unit not implemented by singular")
+end
+
+function deepcopy_internal(a::n_unknownsingularcoefficient, dict::IdDict)
+   return parent(a)(libSingular.n_Copy(a.ptr, parent(a).ptr))
+end
+
+one(R::N_UnknownSingularCoefficientRing) = R(libSingular.n_Init(1, R.ptr))
+
+zero(R::N_UnknownSingularCoefficientRing) = R(libSingular.n_Init(0, R.ptr))
+
+one(a::n_unknownsingularcoefficient) = one(parent(a))
+
+zero(a::n_unknownsingularcoefficient) = zero(parent(a))
+
+isone(a::n_unknownsingularcoefficient) = Bool(libSingular.n_IsOne(a.ptr, parent(a).ptr))
+
+iszero(a::n_unknownsingularcoefficient) = Bool(libSingular.n_IsZero(a.ptr, parent(a).ptr))
+
+function hash(a::n_unknownsingularcoefficient, h::UInt)
+   error("hash not implemented by singular")
+end
+
+###############################################################################
+#
+#   String I/O
+#
+###############################################################################
+
+function AbstractAlgebra.expressify(a::n_unknownsingularcoefficient; context = nothing)::Any
+   # TODO this easy method might not be the best
+   libSingular.StringSetS("")
+   libSingular.n_Write(a.ptr, parent(a).ptr, false)
+   s = libSingular.StringEndS()
+   e = Meta.parse(s)
+   if isa(e, Expr) && e.head == :incomplete
+      return s
+   else
+      return e
+   end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", a::n_unknownsingularcoefficient)
+   libSingular.StringSetS("")
+   libSingular.n_Write(a.ptr, parent(a).ptr, false)
+   m = libSingular.StringEndS()
+   print(io, m)
+end
+
+function show(io::IO, a::n_unknownsingularcoefficient)
+   libSingular.StringSetS("")
+   libSingular.n_Write(a.ptr, parent(a).ptr, false)
+   m = libSingular.StringEndS()
+   print(io, m)
+end
+
+###############################################################################
+#
+#   Unary operators
+#
+###############################################################################
+
+function -(a::n_unknownsingularcoefficient)
+   R = parent(a)
+   n = libSingular.n_Neg(a.ptr, R.ptr)
+   return R(n)
+end
+
+###############################################################################
+#
+#   Binary operators
+#
+###############################################################################
+
+function +(a::n_unknownsingularcoefficient, b::n_unknownsingularcoefficient)
+   check_parent(a, b)
+   R = parent(a)
+   n = libSingular.n_Add(a.ptr, b.ptr, R.ptr)
+   return R(n)
+end
+
+function -(a::n_unknownsingularcoefficient, b::n_unknownsingularcoefficient)
+   check_parent(a, b)
+   R = parent(a)
+   n = libSingular.n_Sub(a.ptr, b.ptr, R.ptr)
+   return R(n)
+end
+
+function *(a::n_unknownsingularcoefficient, b::n_unknownsingularcoefficient)
+   check_parent(a, b)
+   R = parent(a)
+   n = libSingular.n_Mult(a.ptr, b.ptr, R.ptr)
+   return R(n)
+end
+
+###############################################################################
+#
+#   Comparison
+#
+###############################################################################
+
+function ==(a::n_unknownsingularcoefficient, b::n_unknownsingularcoefficient)
+   check_parent(a, b)
+   R = parent(a)
+   return libSingular.n_Equal(a.ptr, b.ptr, R.ptr)
+end
+
+###############################################################################
+#
+#   Powering
+#
+###############################################################################
+
+function ^(x::n_unknownsingularcoefficient, y::Int)
+    y < 0 && throw(DomainError(y, "exponent must be non-negative"))
+    if isone(x)
+       return x
+    elseif y == 0
+       return one(parent(x))
+    elseif y == 1
+       return x
+    else
+       p = libSingular.n_Power(x.ptr, y, parent(x).ptr)
+       return parent(x)(p)
+    end
+end
+
+###############################################################################
+#
+#   Parent call functions
+#
+###############################################################################
+
+function (R::N_UnknownSingularCoefficientRing)(x::Integer)
+   return n_unknownsingularcoefficient(R, libSingular.n_InitMPZ(BigInt(x), R.ptr))
+end
+
+function (R::N_UnknownSingularCoefficientRing)(n::libSingular.number_ptr)
+   return n_unknownsingularcoefficient(R, n)
+end
+
+function (R::N_UnknownSingularCoefficientRing)(a::n_unknownsingularcoefficient)
+   parent(a) === R || error("Unable to coerce element")
+   return a
+end
+

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -13,6 +13,13 @@ mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
    ord::Symbol
    refcount::Int
 
+   # take ownership of a ring ptr
+   function PolyRing{T}(r::libSingular.ring_ptr, b, o::Symbol) where T
+      d = new(r, b, o, 1)
+      finalizer(_PolyRing_clear_fn, d)
+      return d
+   end
+
    function PolyRing{T}(R::Union{Ring, Field}, s::Array{Symbol, 1},
          ord_sym::Symbol, cached::Bool = true,
          ordering::libSingular.rRingOrder_t = ringorder_dp,
@@ -61,13 +68,6 @@ mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
          return d
       end
    end
-end
-
-function (R::PolyRing{T})(r::libSingular.ring_ptr) where T
-   new_r = deepcopy(R)
-   new_ptr = new_r.ptr
-   new_r.ptr = r
-   return new_r
 end
 
 function _PolyRing_clear_fn(R::PolyRing)

--- a/test/caller-test.jl
+++ b/test/caller-test.jl
@@ -88,3 +88,53 @@
     @test 0 == reduce(x1*x2^2*x5*x6^2*x7^2*x9 - 1, id)
     @test 0 == reduce(x1*x2*x3*x4*x5*x6*x7*x8*x9 - 1, id)
 end
+
+@testset "caller.LibSolve" begin
+   R, (x,) = PolynomialRing(Singular.QQ, ["s"])
+   l = Singular.LibSolve.solve(Ideal(R, [x^5+1]))
+   S = l[1]
+   @test isa(S, Singular.PolyRing{Singular.n_unknownsingularcoefficient})
+   for y in l[2][:SOL]
+      @test isa(y^5+1, Singular.n_unknownsingularcoefficient)
+   end
+end
+
+@testset "caller.LibNormal..." begin
+   R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
+   I = Ideal(R, z-x^4, z-y^6)
+   l = Singular.LibNormal.normal(I)
+   S = l[1][1][1]
+   @test isa(S, Singular.PolyRing{n_Q})
+   @test base_ring(gens(l[1][1][2][:norid])[1]*gens(S)[1]) == QQ
+
+   F, a = FiniteField(5, 3, "b")
+   R, (x, y, z) = PolynomialRing(F, ["x", "y", "z"])
+   I = Ideal(R, a*z-x^4, z-y^6)
+   l = Singular.LibNormal.normal(I)
+   S = l[1][1][1]
+   @test isa(S, Singular.PolyRing{n_GF})
+   @test base_ring(gens(l[1][1][2][:norid])[1]*gens(S)[1]*a) == F
+
+   R, (x, y, z) = PolynomialRing(Fp(17), ["x", "y", "z"])
+   I = Ideal(R, z-x^4, z-y^6)
+   l = Singular.LibNormal.normal(I)
+   S = l[1][1][1]
+   @test isa(S, Singular.PolyRing{n_Zp})
+   @test base_ring(gens(l[1][1][2][:norid])[1]*gens(S)[1]) == Fp(17)
+
+   F, (a, b, c) = FunctionField(Fp(17), ["a", "b", "c"])
+   R, (x, y, z) = PolynomialRing(F, ["x", "y", "z"])
+   I = Ideal(R, a*z-x^4, b*c*z-y^6)
+   l = Singular.LibNormal.normal(I)
+   S = l[1][1][1]
+   @test isa(S, Singular.PolyRing{n_transExt})
+   @test base_ring(gens(l[1][1][2][:norid])[1]*gens(S)[1]*a) == F
+
+   F, (a, b, c) = FunctionField(QQ, ["a", "b", "c"])
+   R, (x, y, z) = PolynomialRing(F, ["x", "y", "z"])
+   I = Ideal(R, a*z-x^4, b*c*z-y^6)
+   l = Singular.LibNormal.normal(I)
+   S = l[1][1][1]
+   @test isa(S, Singular.PolyRing{n_transExt})
+   @test base_ring(gens(l[1][1][2][:norid])[1]*gens(S)[1]*a) == F
+end


### PR DESCRIPTION
This is not serious yet and cannot be tried because it requires modifications to the jll's. I am just looking for comments and suggestions at this point. The main problem is creating a meaningful coefficient ring from the ring that singular returns. Since there is a wide variety of possibilities here, it seems impossible to cover all cases. Therefore, I propose having an `UnknownSingularCoefficientRing` with elements of type `n_unknownsingularcoefficient` as a fallback and implementing the search for special cases as we need them. For example, in https://github.com/oscar-system/Singular.jl/issues/187 the coefficient ring does not have a meaningful Nemo equivalent. Here is what it currently looks like (BTW I find it ironic that the answer is called SOL:):

```
julia> R, (s,) = PolynomialRing(Singular.QQ, ["s"])
(Singular Polynomial Ring (QQ),(s),(dp(1),C), spoly{n_Q}[s])

julia> I = Singular.Ideal(R, [s^33-3*s^32-6*s^31-s^30+3*s^23-s^15])
Singular Ideal over Singular Polynomial Ring (QQ),(s),(dp(1),C) with generators (s^33-3*s^32-6*s^31-s^30+3*s^23-s^15)

julia> Singular.LibSolve.solve(I)
...
// 'solve' created a ring, in which a list SOL of numbers (the complex solutions)
// is stored.
// To access the list of complex solutions, type (if the name R was assigned
// to the return value):
        setring R; SOL; 
2-element Array{Any,1}:
 Singular Polynomial Ring (complex,8,8,i),(s),(lp(1),C)
 Dict{Symbol,Any}(:SOL => Singular.n_unknownsingularcoefficient[-0.89521895, 4.4114706, (-1.1482541+i*0.17026655), (-1.1482541-i*0.17026655), (-0.66557296+i*0.58989253), (-0.66557296-i*0.58989253), (-0.56567524+i*0.74847289), (-0.56567524-i*0.74847289), (-0.090798442+i*0.87424398), (-0.090798442-i*0.87424398), (0.11962281+i*0.88093791), (0.11962281-i*0.88093791), (0.53509334+i*0.68993065), (0.53509334-i*0.68993065), (0.69319204+i*0.53157745), (0.69319204-i*0.53157745), (0.86426672-i*0.11380014), (0.86426672+i*0.11380014), 0])

julia> ans[2][:SOL]
19-element Array{Singular.n_unknownsingularcoefficient,1}:
 -0.89521895
 4.4114706
 (-1.1482541+i*0.17026655)
 (-1.1482541-i*0.17026655)
 (-0.66557296+i*0.58989253)
 (-0.66557296-i*0.58989253)
 (-0.56567524+i*0.74847289)
 (-0.56567524-i*0.74847289)
 (-0.090798442+i*0.87424398)
 (-0.090798442-i*0.87424398)
 (0.11962281+i*0.88093791)
 (0.11962281-i*0.88093791)
 (0.53509334+i*0.68993065)
 (0.53509334-i*0.68993065)
 (0.69319204+i*0.53157745)
 (0.69319204-i*0.53157745)
 (0.86426672-i*0.11380014)
 (0.86426672+i*0.11380014)
 0

julia> ans[10]
(-0.090798442-i*0.87424398)

julia> typeof(ans)
Singular.n_unknownsingularcoefficient
```