### PR TITLE
Add basic .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.jl]
+indent_size = 3
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This is honored by a bunch of editors, including the GitHub editor, and there are plugins using it for many others (including Visual Studio Code and vim; see https://editorconfig.org for a list).

It'll certainly not cover all use cases and all users/developers, but at least some (e.g. it is used by the editor I use), and I don't see any downsides to having it?