### PR TITLE
CI: reduce the number of macOS jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,12 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
+        exclude:
+          # Reduce the number of macOS jobs, as fewer can be run in parallel
+          - os: macos-latest
+            julia-version: '1.3'
+          - os: macos-latest
+            julia-version: '1.4'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions lets us run fewer macOS jobs than Linux jobs in parallel.
As a result, waiting for macOS jobs to finish is the primary bottleneck
for our CI runs (the jobs are not really slower, it just takes longer to
process them all).

Running 2 instead of 4 doubles our throughput here.