### PR TITLE
CI: test against Julia 1.6, too

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          - '1.6-nightly'
           - 'nightly'
         julia-arch:
           - x64


### PR DESCRIPTION
Julia 1.6 and nightly (= 1.7) have already diverged quite a bit; now that Julia 1.6 beta is available on GitHub Actions, let's test against that, too.

UPDATE: the announcement indicated this should work, but it doesn't... reported at https://github.com/julia-actions/setup-julia/issues/66