### PR TITLE
no more show_minus_one, needs_parentheses

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -42,10 +42,9 @@ import Nemo: add!, addeq!, base_ring, canonical_unit,
              finish, gcdinv, gen, gens, get_field, intersect, isconstant,
              isgen, ismonomial, inflate, isnegative, isone,
              isterm, isunit, iszero, lift, lc, lt, lm, monomials,
-             MPolyBuildCtx, mul!, needs_parentheses,
-             nvars, ordering, parent_type,
+             MPolyBuildCtx, mul!, nvars, ordering, parent_type,
              parent, primpart, promote_rule, push_term!,
-             reconstruct, remove, set_field!, show_minus_one, sort_terms!,
+             reconstruct, remove, set_field!, sort_terms!,
              symbols, terms, total_degree, valuation,
              var_index, vars, zero!, ResidueRing
 

--- a/src/libsingular/antic/nf_elem.jl
+++ b/src/libsingular/antic/nf_elem.jl
@@ -41,12 +41,7 @@ end
 
 function nf_elemWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)::Nemo.nf_elem
-   if Nemo.needs_parentheses(n)
-      str = "("*string(n)*")"
-   else
-      str = string(n)
-   end
-   libSingular.StringAppendS(str);
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
    nothing
 end
 

--- a/src/libsingular/coeffs.jl
+++ b/src/libsingular/coeffs.jl
@@ -164,6 +164,16 @@ function number(j::T, line_number) where {T <: Nemo.RingElem}
 end
 =#
 
+# singular requires a method to print coefficient objects as string without any
+# precedence information. TODO move this to AA
+function stringify_wrt_times(n)
+   prec = AbstractAlgebra.prec_inf_Times
+   obj = AbstractAlgebra.canonicalize(AbstractAlgebra.expressify(n))
+   S = AbstractAlgebra.printer([])
+   AbstractAlgebra.printExpr(S, obj, prec, prec)
+   str = AbstractAlgebra.getstring(S)
+end
+
 ###############################################################################
 #
 #   Includes

--- a/src/libsingular/flint/fmpq.jl
+++ b/src/libsingular/flint/fmpq.jl
@@ -40,13 +40,8 @@ end
 
 function fmpqWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)::Nemo.fmpq
-    if Nemo.needs_parentheses(n)
-        str = "("*string(n)*")"
-    else
-        str = string(n)
-    end
-    libSingular.StringAppendS(str);
-    nothing
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
+   nothing
 end
 
 ###############################################################################

--- a/src/libsingular/flint/fmpz.jl
+++ b/src/libsingular/flint/fmpz.jl
@@ -39,14 +39,9 @@ function fmpzCoeffWrite(cf::Ptr{Cvoid}, d::Cint)
 end
 
 function fmpzWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
-    n = julia(a)::Nemo.fmpz
-    if Nemo.needs_parentheses(n)
-        str = "("*string(n)*")"
-    else
-        str = string(n)
-    end
-    libSingular.StringAppendS(str);
-    nothing
+   n = julia(a)::Nemo.fmpz
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
+   nothing
 end
 
 ###############################################################################

--- a/src/libsingular/flint/fq_nmod.jl
+++ b/src/libsingular/flint/fq_nmod.jl
@@ -41,13 +41,7 @@ end
 
 function fq_nmodWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)::Nemo.fq_nmod
-   # parenthesize wrt * since this is probably a coeff. TODO move this to AA
-   prec = AbstractAlgebra.prec_inf_Times
-   obj = AbstractAlgebra.canonicalize(AbstractAlgebra.expressify(n))
-   S = AbstractAlgebra.printer([])
-   AbstractAlgebra.printExpr(S, obj, prec, prec)
-   str = AbstractAlgebra.getstring(S)
-   libSingular.StringAppendS(str)
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
    nothing
 end
 

--- a/src/libsingular/nemo/Fields.jl
+++ b/src/libsingular/nemo/Fields.jl
@@ -44,12 +44,7 @@ end
 
 function nemoFieldWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)
-   if Nemo.needs_parentheses(n)
-      str = "("*string(n)*")"
-   else
-      str = string(n)
-   end
-   libSingular.StringAppendS(str);
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
    nothing
 end
 

--- a/src/libsingular/nemo/Rings.jl
+++ b/src/libsingular/nemo/Rings.jl
@@ -44,12 +44,7 @@ end
 
 function nemoRingWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)
-   if Nemo.needs_parentheses(n)
-      str = "("*string(n)*")"
-   else
-      str = string(n)
-   end
-   libSingular.StringAppendS(str);
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
    nothing
 end
 

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -387,4 +387,3 @@ mutable struct n_unknown{T <: Nemo.RingElem} <: Nemo.RingElem
    parent::CoefficientRing{T}
 
 end
-

--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -118,11 +118,7 @@ function show(io::IO, n::n_GF)
    print(io, m)
 end
 
-needs_parentheses(x::n_GF) = false
-
 isnegative(x::n_GF) = false
-
-show_minus_one(::Type{n_GF}) = false
 
 ###############################################################################
 #

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -112,20 +112,13 @@ end
 
 function show(io::IO, n::n_Q)
     libSingular.StringSetS("")
-
     libSingular.n_Write(n.ptr, parent(n).ptr, false)
-
     m = libSingular.StringEndS()
-
     print(io,m)
 end
 
-needs_parentheses(x::n_Q) = false
-
 isnegative(x::n_Q) = !libSingular.n_GreaterZero(x.ptr, parent(x).ptr) &&
                       !iszero(x)
-
-show_minus_one(::Type{n_Q}) = false
 
 ###############################################################################
 #

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -108,21 +108,13 @@ end
 
 function show(io::IO, n::n_Z)
    libSingular.StringSetS("")
-
    libSingular.n_Write(n.ptr, parent(n).ptr, false)
-
    m = libSingular.StringEndS()
-
    print(io,m)
-
 end
-
-needs_parentheses(x::n_Z) = false
 
 isnegative(x::n_Z) = !libSingular.n_GreaterZero(x.ptr, parent(x).ptr) &&
                       !iszero(x)
-
-show_minus_one(::Type{n_Z}) = false
 
 ###############################################################################
 #

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -108,11 +108,7 @@ function show(io::IO, n::n_Zn)
    print(io, m)
 end
 
-needs_parentheses(x::n_Zn) = false
-
 isnegative(x::n_Zn) = false
-
-show_minus_one(::Type{n_Zn}) = true
 
 ###############################################################################
 #

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -108,13 +108,9 @@ function show(io::IO, n::n_Zp)
    print(io, m)
 end
 
-needs_parentheses(x::n_Zp) = false
-
 function isnegative(x::n_Zp)
    return x > parent(x)(div(characteristic(parent(x)), ZZ(2)))
 end
-
-show_minus_one(::Type{n_Zp}) = false
 
 ###############################################################################
 #

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -145,19 +145,30 @@ function show(io::IO, F::N_FField)
    print(io, "Function Field over ", base_ring(F), " with transcendence basis ", transcendence_basis(F))
 end
 
-function show(io::IO, n::n_transExt)
+function AbstractAlgebra.expressify(n::n_transExt; context = nothing)::Any
+   # TODO this easy method might not be the best
    libSingular.StringSetS("")
-
    libSingular.n_Write(n.ptr, parent(n).ptr, false)
-
-   m = libSingular.StringEndS()
-
-   print(io, m)
+   s = libSingular.StringEndS()
+   e = Meta.parse(s)
+   if !isa(e, Expr)
+      return e
+   elseif e.head == :incomplete
+      return s
+   elseif e.head == :call && length(e.args) == 3 && e.args[1] == :/
+      e.args[1] = ://
+      return e
+   else
+      return e
+   end
 end
 
-needs_parentheses(x::n_transExt) = false
-
-show_minus_one(::Type{n_transExt}) = false
+function show(io::IO, n::n_transExt)
+   libSingular.StringSetS("")
+   libSingular.n_Write(n.ptr, parent(n).ptr, false)
+   m = libSingular.StringEndS()
+   print(io, m)
+end
 
 ###############################################################################
 #

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -91,6 +91,8 @@ end
 Return symbols for the generators of the polynomial ring $R$.
 """
 function symbols(R::PolyRing)
+   # TODO calling show to get the symbols is a bad idea
+   # wrap this from singular: char* rRingVar(short i, const ring r)
    io = IOBuffer();
    symbols = Array{Symbol,1}(undef, 0)
    for g in gens(R)
@@ -361,10 +363,6 @@ function show(io::IO, a::spoly)
    s = libSingular.p_String(a.ptr, parent(a).ptr)
    print(io, s)
 end
-
-show_minus_one(::Type{spoly{T}}) where T <: Nemo.RingElem = show_minus_one(T)
-
-needs_parentheses(x::spoly) = length(x) > 1
 
 isnegative(x::spoly) = isconstant(x) && !iszero(x) && isnegative(coeff(x, 0))
 

--- a/test/number/n_GF-test.jl
+++ b/test/number/n_GF-test.jl
@@ -57,9 +57,6 @@ end
    @test sprint(show, "text/plain", x) == "x"
    @test sprint(show, "text/plain", x^2) == "x^2"
    @test sprint(show, "text/plain", x^11) == "x^11"
-
-   @test !Singular.AbstractAlgebra.isnegative(x)
-   @test !Singular.AbstractAlgebra.needs_parentheses(x)
 end
 
 @testset "n_GF.manipulation..." begin

--- a/test/number/n_transExt-test.jl
+++ b/test/number/n_transExt-test.jl
@@ -42,6 +42,17 @@ end
    F, (a, b, c) = FunctionField(QQ, ["a", "b", "c"])
 
    @test string(3*a*b + 2*c) == "(3*a*b+2*c)"
+
+   R, (x, y, z) = PolynomialRing(F, ["x", "y", "z"])
+
+   p = (3*a*b+2*c)*x+(c^2)*y+b*z
+   q = (a+b//c)*x^2
+   # singular's printing
+   @test string(p) == "(3*a*b+2*c)*x+(c^2)*y+(b)*z"
+   @test string(q) == "(a*c+b)/(c)*x^2"
+   # AA's printing
+   @test sprint(show, "text/plain", p) == "(3*a*b + 2*c)*x + c^2*y + b*z"
+   @test sprint(show, "text/plain", q) == "(a*c + b)//c*x^2"
 end
 
 @testset "n_transExt.manipulation..." begin


### PR DESCRIPTION
This includes a great implementation of `expressify` for `n_transExt`.
Note that `show_minus_one` and `needs_parentheses` were being imported from Nemo.