### PR TITLE
Fix bogus promote_rule(n_Q, n_Q) = n_Z

### DIFF
--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -339,7 +339,7 @@ promote_rule(C::Type{n_Q}, ::Type{T}) where {T <: Integer} = n_Q
 
 promote_rule(C::Type{n_Q}, ::Type{Nemo.fmpz}) = n_Q
 
-promote_rule(C::Type{n_Q}, ::Type{n_Q}) = n_Z
+promote_rule(C::Type{n_Q}, ::Type{n_Z}) = n_Q
 
 Rational{T}(x::n_Q) where {T} = convert(T, numerator(x)) // convert(T, denominator(x))
 Rational(x::n_Q) = Integer(numerator(x)) // Integer(denominator(x))


### PR DESCRIPTION
Clearly promoting values of type n_Q to type n_Z makes no sense.
Most likely what was meant here is the reverse: n_Z promotes to n_Q.