### PR TITLE
proper expressify for n_transExt

### DIFF
--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -309,6 +309,7 @@ mutable struct N_FField <: Field
    ptr::libSingular.coeffs_ptr
    base_ring::Field
    refcount::Int
+   S::Array{Symbol, 1}
 
    function N_FField(F::Field, S::Array{Symbol, 1}, cached::Bool = true)
       if cached && haskey(N_FFieldID, (F, S))
@@ -317,7 +318,7 @@ mutable struct N_FField <: Field
          v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in S]
          cf = libSingular.nCopyCoeff(F.ptr)
          ptr = libSingular.transExt_helper(cf, v)
-         d = new(ptr, F, 1)
+         d = new(ptr, F, 1, S)
          finalizer(_Ring_finalizer, d)
          if cached
             N_FFieldID[F, S] = d

--- a/test/number/n_transExt-test.jl
+++ b/test/number/n_transExt-test.jl
@@ -35,6 +35,12 @@ end
 
    @test sprint(show, "text/plain", q) == "(a*c + b)//c*x^2"
    @test string(q) == "(a*c + b)//c*x^2"
+
+   @test sprint(show, "text/plain", R(3)) == "3"
+   @test string(R(3)) == "3"
+
+   @test sprint(show, "text/plain", R(big(3)^80)) == string(big(3)^80)
+   @test string(R(big(3)^80)) == string(big(3)^80)
 end
 
 @testset "n_transExt.manipulation" begin


### PR DESCRIPTION
fixes a todo in the code and the following bad behavior:
```
julia> dump(Singular.AbstractAlgebra.expressify(FunctionField(QQ, ["a", "b", "c"])[1](BigInt(3)^80)))
Expr
  head: Symbol macrocall
  args: Array{Any}((3,))
    1: GlobalRef
      mod: Module Core
      name: Symbol @int128_str
    2: Nothing nothing
    3: String "147808829414345923316083210206383297601"
```
