### PR TITLE
getting the elements out of the n_unknown

### DIFF
--- a/src/MessyHacks.jl
+++ b/src/MessyHacks.jl
@@ -1,0 +1,52 @@
+#=
+   messy hack #1:
+
+   Getting the nemo ring element out of the darn n_unknown struct:
+
+   all types would be handled by the general signature
+
+   function (R::parent_type(T))(a::n_unknown{T}) where {T <: Nemo.RingElem}
+
+   but this is an error, so the following nonsense ensues.
+
+   If you want your stuff to work with the R(a::n_unknown{T}) syntax, you will
+   have to add it to the {zero|one}_parameter_types list below or make your
+   own special definition.
+=#
+
+let zero_parameter_types = [
+      Nemo.FlintIntegerRing => Nemo.fmpz,
+      Nemo.FlintRationalField => Nemo.fmpq,
+      Nemo.FmpzPolyRing => Nemo.fmpz_poly,
+      Nemo.FqNmodFiniteField => Nemo.fq_nmod,
+      Nemo.FqFiniteField => Nemo.fq,
+      Nemo.AnticNumberField => Nemo.nf_elem
+   ],
+
+   one_parameter_types = [
+      AbstractAlgebra.Generic.LaurentSeriesRing =>
+         AbstractAlgebra.Generic.LaurentSeriesRingElem,
+      AbstractAlgebra.Generic.FracField =>
+         AbstractAlgebra.Generic.Frac
+   ]
+
+   for (A, B) in zero_parameter_types
+      @eval begin
+         function (R::($A))(a::Singular.n_unknown{($B)})
+            GC.@preserve a begin
+               return R(libSingular.julia(libSingular.cast_number_to_void(a.ptr)))
+            end
+         end
+      end
+   end
+
+   for (A, B) in one_parameter_types
+      @eval begin
+         function (R::($A){T})(a::Singular.n_unknown{($B){T}}) where T <: RingElement
+            GC.@preserve a begin
+               return R(libSingular.julia(libSingular.cast_number_to_void(a.ptr)))
+            end
+         end
+      end
+   end
+end

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -202,4 +202,6 @@ include("Meta.jl")
 
 include("Map.jl")
 
+include("MessyHacks.jl")
+
 end # module

--- a/src/libsingular/flint/fq.jl
+++ b/src/libsingular/flint/fq.jl
@@ -41,13 +41,7 @@ end
 
 function fqWrite(a::Ptr{Cvoid}, cf::Ptr{Cvoid})
    n = julia(a)::Nemo.fq
-   # parenthesize wrt * since this is probably a coeff. TODO move this to AA
-   prec = AbstractAlgebra.prec_inf_Times
-   obj = AbstractAlgebra.canonicalize(AbstractAlgebra.expressify(n))
-   S = AbstractAlgebra.printer([])
-   AbstractAlgebra.printExpr(S, obj, prec, prec)
-   str = AbstractAlgebra.getstring(S)
-   libSingular.StringAppendS(str)
+   libSingular.StringAppendS(libSingular.stringify_wrt_times(n))
    nothing
 end
 

--- a/test/libsingular/nemo-test.jl
+++ b/test/libsingular/nemo-test.jl
@@ -7,6 +7,8 @@
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{Nemo.fmpq})
+   @test isa(Nemo.QQ(f1c[1]), Nemo.fmpq)
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)
@@ -55,8 +57,9 @@ end
    f3 = x^2 + 2x + 1
 
    f1c = [c for c in coefficients(f1)]
-
    @test isa(f1c[1], Singular.n_unknown{Nemo.fmpz})
+   @test isa(Nemo.ZZ(f1c[1]), Nemo.fmpz)
+   @test !isempty(string(f1c[1]))
 
    @test string(first(coefficients(f3))) == "1"
 
@@ -104,6 +107,8 @@ end
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{Nemo.fq_nmod})
+   @test isa(F(f1c[1]), Nemo.fq_nmod)
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)
@@ -157,6 +162,8 @@ end
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{Nemo.fq})
+   @test isa(F(f1c[1]), Nemo.fq)
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)
@@ -209,6 +216,8 @@ end
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{Nemo.nf_elem})
+   @test isa(K(f1c[1]), Nemo.nf_elem)
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)
@@ -260,6 +269,8 @@ end
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{AbstractAlgebra.Generic.Frac{Nemo.fmpz}})
+   @test isa(U(f1c[1]), AbstractAlgebra.Generic.Frac{Nemo.fmpz})
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)
@@ -307,6 +318,8 @@ end
 
    f1c = [c for c in coefficients(f1)]
    @test isa(f1c[1], Singular.n_unknown{Nemo.fmpz_poly})
+   @test isa(U(f1c[1]), Nemo.fmpz_poly)
+   @test !isempty(string(f1c[1]))
 
    @test f1 + 2 == 2 + f1
    @test f1 - 2 == -(2 - f1)


### PR DESCRIPTION
fixes https://github.com/oscar-system/Singular.jl/issues/172 as best as I can (which is to say, not very well).

I am _keeping_ the following bad behaviour, simply because it is too messy to fix and because of certain design decisions:
```
julia> K = Singular.Nemo.QQ
Rational Field

julia> R, (x, y) = Singular.PolynomialRing(K, ["x", "y"])
(Singular Polynomial Ring (Coeffs(17)),(x,y),(dp(2),C), spoly{Singular.n_unknown{Nemo.fmpq}}[x, y])

julia> base_ring(R) == K
false
```