### PR TITLE
Add fancy orderings

### DIFF
--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -48,7 +48,7 @@ polynomials that is not documented in the general multivariate interface.
 
 ```julia
 PolynomialRing(R::Union{Ring, Field}, s::Array{String, 1};
-   cached::Bool = true, ordering::Symbol = :degrevlex,
+   cached::Bool = true, ordering = :degrevlex,
       ordering2::Symbol = :comp1min, degree_bound::Int = 0)
 ```
 
@@ -61,14 +61,18 @@ coefficient ring, list of variable names, ordering and degree bound. This is
 accomplished by making use of a global cache. If this is not the desired behaviour,
 `false` can be passed to the optional argument `cached`.
 
-Two orderings can be specified, one for term ordering of the polynomials, and another
+If the first ordering `ordering` is specified as a symbol, then
+two orderings can be specified, one for term ordering of the polynomials, and another
 for ordering of module components. They can occur in either order, the first taking
 precedence over the other, when the polynomials are used to represent module generators.
 If either is not specified, the indicated default is used.
+The options for polynomial term ordering are, `:lex`, `:deglex`, `:degrevlex`,
+`:neglex`, `:negdeglex` and `:negdegrevlex`, and the options for module component ordering
+are `comp1min` and `comp1max`.
 
-The options for polynomial term ordering are the symbols, `:lex`, `:deglex`, `:degrevlex`,
-`:neglex`, `:negdeglex` and `:negdegrevlex`, and the options for module component ordering are `comp1min` and
-`comp1max`.
+If the first ordering `ordering` is specifed as a non-symbol, the second ordering
+`ordering2` will be ignored. For specifying non-symbolic term orderings, please
+see the Term orderings section below.
 
 If one has an a priori bound on the degree in each variable of a polynomial (including
 for all intermediate computations in this ring), one can specify it using the
@@ -118,6 +122,83 @@ push_term!(C, ZZ(1), [1, 2])
 push_term!(C, ZZ(3), [1, 1])
 push_term!(C, -ZZ(1), [0, 1])
 f = finish(C)
+```
+
+### Term orderings
+
+A general term ordering can be constructed as a product of one or more of the
+following block orderings.
+
+```@docs
+ordering_lp(nvars::Int = 1)
+```
+
+```@docs
+ordering_rp(nvars::Int = 1)
+```
+
+```@docs
+ordering_dp(nvars::Int = 1)
+```
+
+```@docs
+ordering_Dp(nvars::Int = 1)
+```
+
+```@docs
+ordering_Wp(w::Vector{Int})
+```
+
+```@docs
+ordering_Wp(w::Vector{Int})
+```
+
+```@docs
+ordering_ls(nvars::Int = 1)
+```
+
+```@docs
+ordering_rs(nvars::Int = 1)
+```
+
+```@docs
+ordering_ds(nvars::Int = 1)
+```
+
+```@docs
+ordering_Ds(nvars::Int = 1)
+```
+
+```@docs
+ordering_ws(w::Vector{Int})
+```
+
+```@docs
+ordering_Ws(w::Vector{Int})
+```
+
+```@docs
+ordering_a(w::Vector{Int})
+```
+
+```@docs
+ordering_M(m::Matrix{Int}, checked::Bool = true)
+```
+
+```@docs
+ordering_C()
+```
+
+```@docs
+ordering_c()
+```
+
+**Examples**
+
+```julia
+PolynomialRing(QQ, "x".*string.(1:8), ordering = ordering_M([1 2; 3 5])*ordering_lp(3)*ordering_wp([1, 2, 3]))
+
+PolynomialRing(QQ, "x".*string.(1:5), ordering = ordering_dp(3)*ordering_dp())
 ```
 
 ### Polynomial ring macros

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -126,9 +126,13 @@ function __init__()
    global ringorder_Ds = libSingular.ringorder_Ds
    global ringorder_ws = libSingular.ringorder_ws
    global ringorder_Ws = libSingular.ringorder_Ws
+   global ringorder_a  = libSingular.ringorder_a
    global ringorder_M  = libSingular.ringorder_M
    global ringorder_c  = libSingular.ringorder_c
    global ringorder_C  = libSingular.ringorder_C
+   global ringorder_s  = libSingular.ringorder_s
+   global ringorder_S  = libSingular.ringorder_S
+   global ringorder_IS = libSingular.ringorder_IS
 
    global sym2ringorder = Dict{Symbol, libSingular.rRingOrder_t}(
      :lex => ringorder_lp,

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -118,10 +118,15 @@ function __init__()
    global ringorder_rp = libSingular.ringorder_rp
    global ringorder_dp = libSingular.ringorder_dp
    global ringorder_Dp = libSingular.ringorder_Dp
+   global ringorder_wp = libSingular.ringorder_wp
+   global ringorder_Wp = libSingular.ringorder_Wp
    global ringorder_ls = libSingular.ringorder_ls
    global ringorder_rs = libSingular.ringorder_rs
    global ringorder_ds = libSingular.ringorder_ds
    global ringorder_Ds = libSingular.ringorder_Ds
+   global ringorder_ws = libSingular.ringorder_ws
+   global ringorder_Ws = libSingular.ringorder_Ws
+   global ringorder_M  = libSingular.ringorder_M
    global ringorder_c  = libSingular.ringorder_c
    global ringorder_C  = libSingular.ringorder_C
 

--- a/src/caller.jl
+++ b/src/caller.jl
@@ -45,25 +45,24 @@ end
 
 # take ownership of r
 function create_ring_from_singular_ring(r::libSingular.ring_ptr)
-   ordering = libSingular.ring_ordering_as_symbol(r)
    c = libSingular.rCoeffPtr(r)
    if libSingular.nCoeff_is_Q(c)
-      return PolyRing{n_Q}(r, QQ, ordering)
+      return PolyRing{n_Q}(r, QQ)
    elseif libSingular.nCoeff_is_Zp(c)
       p = Int(libSingular.n_GetChar(c))
-      return PolyRing{n_Zp}(r, N_ZpField(p), ordering)
+      return PolyRing{n_Zp}(r, N_ZpField(p))
    elseif libSingular.nCoeff_is_GF(c)
       p = Int(libSingular.n_GetChar(c))
       q = Int(libSingular.nfCharQ(c))
       d = round(Int, log(p, q))
       s = Symbol(libSingular.n_ParameterName(0, c))
-      return PolyRing{n_GF}(r, N_GField(p, d, s), ordering)
+      return PolyRing{n_GF}(r, N_GField(p, d, s))
    elseif libSingular.nCoeff_is_transExt(c)
       p = Int(libSingular.n_GetChar(c))
       npars = libSingular.n_NumberOfParameters(c)
       S = [Symbol(libSingular.n_ParameterName(i-1, c)) for i in 1:npars]
       F = N_FField(iszero(p) ? QQ : N_ZpField(p), S)
-      return PolyRing{n_transExt}(r, F, ordering)
+      return PolyRing{n_transExt}(r, F)
    elseif libSingular.nCoeff_is_algExt(c)
       # first create the univariate transcendental extension
       p = Int(libSingular.n_GetChar(c))
@@ -73,10 +72,10 @@ function create_ring_from_singular_ring(r::libSingular.ring_ptr)
       # now create the extension
       minpoly = F(libSingular.algExt_GetMinpoly(c, F.ptr))
       K = N_AlgExtField(libSingular.nCopyCoeff(c), minpoly)
-      return PolyRing{n_algExt}(r, K, ordering)
+      return PolyRing{n_algExt}(r, K)
    else
       basering = N_UnknownSingularCoefficientRing(libSingular.nCopyCoeff(c))
-      return PolyRing{n_unknownsingularcoefficient}(r, basering, ordering)
+      return PolyRing{n_unknownsingularcoefficient}(r, basering)
    end
 end
 

--- a/src/libsingular/rings.jl
+++ b/src/libsingular/rings.jl
@@ -54,15 +54,3 @@ function p_ExtGcd(a::poly_ptr, b::poly_ptr, res::Ptr{poly_ptr}, s::Ptr{poly_ptr}
     rp = reinterpret(Ptr{Nothing},res)
     return p_ExtGcd_internal(a, b, rp, sp, tp, r)
 end
-
-function ring_ordering_as_symbol(r::ring_ptr)
-   if Bool(rRing_ord_pure_dp(r))
-      return :degrevlex
-   elseif Bool(rRing_ord_pure_Dp(r))
-      return :deglex
-   elseif Bool(rRing_ord_pure_lp(r))
-      return :lex
-   else
-      return :unknown
-   end
-end

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -504,12 +504,6 @@ function Base.isless(x::spoly{T}, y::spoly{T}) where T <: Nemo.RingElem
    GC.@preserve x y R return libSingular.p_Compare(x.ptr, y.ptr, R.ptr) < 0
 end
 
-function Base.isequal(x::spoly{T}, y::spoly{T}) where T <: Nemo.RingElem
-   check_parent(x, y)
-   R = parent(x)
-   GC.@preserve x y R return libSingular.p_Compare(x.ptr, y.ptr, R.ptr) == 0
-end
-
 ###############################################################################
 #
 #   Exact division

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1702,7 +1702,7 @@ function deserialize_ordering(b::Vector{Cint})
       elseif o == ringorder_s
          push!(data, sorder_block(o, blk0, Int[]))         
       else
-         error("unknown ordering $(i.order)")
+         error("unknown ordering $o")
       end
     end
     return sordering(data)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -5,17 +5,20 @@ export spoly, PolyRing, change_base_ring, coeff, coefficients,
        exponent_vectors, factor, factor_squarefree, finish, gen,
        has_global_ordering, has_mixed_ordering, has_local_ordering,
        inflate, isgen,
-       ismonomial, isquotient_ring, isterm, jacobian_ideal, jacobian_matrix,
-       jet, leading_coefficient, leading_term, leading_monomial, lead_exponent,
-       leading_exponent_vector, monomials, MPolyBuildCtx,
-       nvars, order, ordering, @PolynomialRing, primpart,
-       push_term!, remove, sort_terms!, symbols, tail, terms, total_degree,
-       trailing_coefficient,
+       ismonomial, isordering_symbolic, isquotient_ring, isterm,
+       jacobian_ideal, jacobian_matrix, jet,
+       leading_coefficient, leading_exponent_vector, leading_term,
+       leading_monomial, lead_exponent,
+       monomials, MPolyBuildCtx,
+       nvars, order, ordering, ordering_as_symbol,
+       @PolynomialRing, primpart, push_term!,
+       remove, sort_terms!, symbols,
+       tail, terms, total_degree, trailing_coefficient,
        valuation, var_index, vars
 
-export lp_order, rp_order, dp_order, Dp_order, wp_order, Wp_order,
-       ls_order, rs_order, ds_order, Ds_order, ws_order, Ws_order,
-       M_order
+export ordering_lp, ordering_rp, ordering_dp, ordering_Dp, ordering_wp, ordering_Wp,
+       ordering_ls, ordering_rs, ordering_ds, ordering_Ds, ordering_ws, ordering_Ws,
+       ordering_a, ordering_M, ordering_c, ordering_C, ordering_s, ordering_S
 
 
 ###############################################################################
@@ -107,6 +110,20 @@ function symbols(R::PolyRing)
 end
 
 ordering(R::PolyRing) = R.ord
+
+@doc Markdown.doc"""
+    isordering_symbolic(R::PolyRing)
+
+Return `true` if the ordering of `R` can be represented as a symbol.
+"""
+isordering_symbolic(R::PolyRing) = isordering_symbolic(R.ord)
+
+@doc Markdown.doc"""
+    ordering_as_symbol(R::PolyRing)
+
+Assuming the ordering of `R` can be represented as a symbol, return that symbol.
+"""
+ordering_as_symbol(R::PolyRing) = ordering_as_symbol(R.ord)
 
 @doc Markdown.doc"""
     degree_bound(R::PolyRing)
@@ -1224,46 +1241,47 @@ end
 #
 ###############################################################################
 
-function _expressify_basic_ordering(h::Symbol, n::Int)
-   if n > 0
-      return Expr(:call, h, n)
-   else
-      return Expr(:call, h)
-   end
-end
-
-function Singular.AbstractAlgebra.expressify(a::sordering; context = nothing)
+function AbstractAlgebra.expressify(a::sordering; context = nothing)
    prod = Expr(:call, :cdot)
    for i in a.data
-      if i.order == Singular.ringorder_lp
-         this = _expressify_basic_ordering(:lp_order, i.blocksize)
-      elseif i.order == Singular.ringorder_rp
-         this = _expressify_basic_ordering(:rp_order, i.blocksize)
-      elseif i.order == Singular.ringorder_dp
-         this = _expressify_basic_ordering(:dp_order, i.blocksize)
-      elseif i.order == Singular.ringorder_Dp
-         this = _expressify_basic_ordering(:Dp_order, i.blocksize)
-      elseif i.order == Singular.ringorder_wp
-         this = Expr(:call, :wp_order, string(i.weights))
-      elseif i.order == Singular.ringorder_Wp
-         this = Expr(:call, :Wp_order, string(i.weights))
-      elseif i.order == Singular.ringorder_ls
-         this = _expressify_basic_ordering(:ls_order, i.blocksize)
-      elseif i.order == Singular.ringorder_rs
-         this = _expressify_basic_ordering(:rs_order, i.blocksize)
-      elseif i.order == Singular.ringorder_ds
-         this = _expressify_basic_ordering(:ds_order, i.blocksize)
-      elseif i.order == Singular.ringorder_Ds
-         this = _expressify_basic_ordering(:Ds_order, i.blocksize)
-      elseif i.order == Singular.ringorder_ws
-         this = Expr(:call, :ws_order, string(i.weights))
-      elseif i.order == Singular.ringorder_Ws
-         this = Expr(:call, :Ws_order, string(i.weights))
-      elseif i.order == Singular.ringorder_M         
-         this = Expr(:call, :M_order, string(transpose(reshape(i.weights, (i.blocksize, i.blocksize)))))
+      if i.order == ringorder_lp
+         this = Expr(:call, :ordering_lp, i.size)
+      elseif i.order == ringorder_rp
+         this = Expr(:call, :ordering_rp, i.size)
+      elseif i.order == ringorder_dp
+         this = Expr(:call, :ordering_dp, i.size)
+      elseif i.order == ringorder_Dp
+         this = Expr(:call, :ordering_Dp, i.size)
+      elseif i.order == ringorder_wp
+         this = Expr(:call, :ordering_wp, string(i.weights))
+      elseif i.order == ringorder_Wp
+         this = Expr(:call, :ordering_Wp, string(i.weights))
+      elseif i.order == ringorder_ls
+         this = Expr(:call, :ordering_ls, i.size)
+      elseif i.order == ringorder_rs
+         this = Expr(:call, :ordering_rs, i.size)
+      elseif i.order == ringorder_ds
+         this = Expr(:call, :ordering_ds, i.size)
+      elseif i.order == ringorder_Ds
+         this = Expr(:call, :ordering_Ds, i.size)
+      elseif i.order == ringorder_ws
+         this = Expr(:call, :ordering_ws, string(i.weights))
+      elseif i.order == ringorder_Ws
+         this = Expr(:call, :ordering_Ws, string(i.weights))
+      elseif i.order == ringorder_a
+         this = Expr(:call, :ordering_a, string(i.weights))
+      elseif i.order == ringorder_M         
+         this = Expr(:call, :ordering_M, string(transpose(reshape(i.weights, (i.size, i.size)))))
+      elseif i.order == ringorder_C
+         this = Expr(:call, :ordering_C)
+      elseif i.order == ringorder_c
+         this = Expr(:call, :ordering_c)
+      elseif i.order == ringorder_S
+         this = Expr(:call, :ordering_S)
+      elseif i.order == ringorder_s
+         this = Expr(:call, :ordering_s, i.size)
       else
-         @assert false
-         this = Expr(:call, :?)
+         this = Expr(:call, :ordering_unknown)
       end
       push!(prod.args, this)
    end
@@ -1278,96 +1296,197 @@ function Base.show(io::IO, a::sordering)
    Singular.AbstractAlgebra.show_via_expressify(io, a)
 end
 
-function _basic_ordering(t::Singular.libSingular.rRingOrder_t, nvars::Int)
-   nvars >= 0 || error("block size must be nonnegative")
-   return sordering([sorder_block(t, nvars, Int[])])
+function _is_basic_ordering(t::libSingular.rRingOrder_t)
+    return t == ringorder_lp || t == ringorder_ls ||
+           t == ringorder_rp || t == ringorder_rs ||
+           t == ringorder_dp || t == ringorder_ds ||
+           t == ringorder_Dp || t == ringorder_Ds
 end
 
-function _global_weighted_ordering(t::Singular.libSingular.rRingOrder_t, v::Vector{Int})
+function _is_weighted_ordering(t::libSingular.rRingOrder_t)
+    return t == ringorder_wp || t == ringorder_ws ||
+           t == ringorder_Wp || t == ringorder_Ws 
+end
+
+function _basic_ordering(t::libSingular.rRingOrder_t, size::Int)
+   size >= 0 || error("block size must be nonnegative")
+   return sordering([sorder_block(t, size, Int[])])
+end
+
+function _global_weighted_ordering(t::libSingular.rRingOrder_t, v::Vector{Int})
    len = length(v)
    len > 0 || error("weight vector must be non-empty")
    all(x->x>0, v) || error("all weights must be positive") 
    return sordering([sorder_block(t, len, v)])
 end
 
-function _local_weighted_ordering(t::Singular.libSingular.rRingOrder_t, v::Vector{Int})
+function _local_weighted_ordering(t::libSingular.rRingOrder_t, v::Vector{Int})
    len = length(v)
    len > 0 || error("weight vector must be non-empty")
-   v[1] != 0 || error("first weight must be nonzero") 
+   v[1] != 0 || error("first weight must be nonzero")
    return sordering([sorder_block(t, len, v)])
 end
 
-lp_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_lp, nvars)
-rp_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_rp, nvars)
-dp_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_dp, nvars)
-Dp_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_Dp, nvars)
-wp_order(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_wp, v)
-Wp_order(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_Wp, v)
-ls_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_ls, nvars)
-rs_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_rs, nvars)
-ds_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_ds, nvars)
-Ds_order(nvars::Int = 0) = _basic_ordering(Singular.ringorder_Ds, nvars)
-ws_order(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_ws, v)
-Ws_order(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_Ws, v)
+ordering_lp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_lp, nvars)
+ordering_rp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_rp, nvars)
+ordering_dp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_dp, nvars)
+ordering_Dp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_Dp, nvars)
+ordering_wp(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_wp, v)
+ordering_Wp(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_Wp, v)
+ordering_ls(nvars::Int = 1) = _basic_ordering(Singular.ringorder_ls, nvars)
+ordering_rs(nvars::Int = 1) = _basic_ordering(Singular.ringorder_rs, nvars)
+ordering_ds(nvars::Int = 1) = _basic_ordering(Singular.ringorder_ds, nvars)
+ordering_Ds(nvars::Int = 1) = _basic_ordering(Singular.ringorder_Ds, nvars)
+ordering_ws(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_ws, v)
+ordering_Ws(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_Ws, v)
 
-function M_order(m::Matrix{Int}, checked::Bool = true)
+ordering_a(v::Vector{Int}) = sordering([sorder_block(ringorder_a, 0, v)])
+
+function ordering_M(m::Matrix{Int}, checked::Bool = true)
    (nr, nc) = size(m)
-   nr > 0 && nr == nc || "weight matrix must be square"
-   !checked || !iszero(Singular.Nemo.det(Singular.Nemo.matrix(Singular.Nemo.ZZ, m))) || error("weight matrix must nonsingular")
-   return sordering([sorder_block(Singular.ringorder_M, nr, vec(transpose(m)))])
+   nr > 0 && nr == nc || error("weight matrix must be square")
+   !checked || !iszero(Nemo.det(Nemo.matrix(Nemo.ZZ, m))) || error("weight matrix must nonsingular")
+   return sordering([sorder_block(ringorder_M, nr, vec(transpose(m)))])
 end
+
+# these three can take a dummy int in singular, but they do nothing with it?
+ordering_C(dummy::Int = 0) = _basic_ordering(Singular.ringorder_C, 0)
+ordering_c(dummy::Int = 0) = _basic_ordering(Singular.ringorder_c, 0)
+ordering_S(dummy::Int = 0) = _basic_ordering(Singular.ringorder_S, 0)
+ordering_s(syz_comp::Int = 0) = sordering([sorder_block(Singular.ringorder_s, syz_comp, Int[])])
 
 function Base.:*(a::sordering, b::sordering)
    return sordering(vcat(a.data, b.data))
 end
 
+function Base.:(==)(a::sordering, b::sordering)
+   if length(a.data) != length(b.data)
+      return false
+   end
+   for i in 1:length(a.data)
+      if a.data[i].order != b.data[i].order
+         return false
+      elseif a.data[i].size != b.data[i].size
+         return false
+      elseif a.data[i].weights != b.data[i].weights
+         return false
+      end
+   end
+   return true
+end
+
+isordering_a_symbol(a::sordering) = isordering_a_symbol_with_symbol(a)[1]
+ordering_as_symbol(a::sordering) = isordering_a_symbol_with_symbol(a)[2]
+
+function isordering_a_symbol_with_symbol(a::sordering)
+   if length(a.data) != 1 && length(a.data) != 2
+      return (false, :unknown)
+   end
+
+   if length(a.data) == 2 && a.data[2].order != ringorder_C
+      return (false, :unknown)
+   end
+
+   o = a.data[1].order
+   if o == ringorder_lp
+      return (true, :lex)
+   elseif o == ringorder_rp
+      return (true, :revlex)
+   elseif o == ringorder_ls
+      return (true, :neglex)
+   elseif o == ringorder_rs
+      return (true, :negrevlex)
+   elseif o == ringorder_dp
+      return (true, :degrevlex)
+   elseif o == ringorder_Dp
+      return (true, :deglex)
+   elseif o == ringorder_ds
+      return (true, :negdegrevlex)
+   elseif o == ringorder_Ds
+      return (true, :negdeglex)
+   elseif o == ringorder_Ds
+      return (true, :negdeglex)
+   elseif o == ringorder_Ds
+      return (true, :negdeglex)
+   elseif o == ringorder_wp
+      return (true, :weightedrevlex)
+   elseif o == ringorder_Wp
+      return (true, :weightedlex)
+   elseif o == ringorder_ws
+      return (false, :negweightedrevlex)
+   elseif o == ringorder_Ws
+      return (false, :negweightedlex)
+   elseif o == ringorder_a
+      return (false, :extraweight)
+   elseif o == ringorder_M
+      return (false, :matrix)
+   elseif o == ringorder_c
+      return (false, :comp1max)
+   elseif o == ringorder_C
+      return (false, :comp1min)
+   else
+      return (false, :unknown)
+   end
+end
+
 function serialize_ordering(nvars::Int, ord::sordering)
    b = Cint[length(ord.data)]
-   offset = 0
-   c_count = 0
-   l = 0;
-   for i in ord.data
-      l += 1
-      if i.order == Singular.ringorder_c || i.order == Singular.ringorder_C
-         if c_count == 0
-            push!(b, Singular.libSingular.ringorder_to_int(i.order))
+   lastvar = 0
+   cC_count = 0
+   for l in 1:length(ord.data)
+      i = ord.data[l]
+      if i.order == ringorder_c || i.order == ringorder_C
+         cC_count += 1
+         if cC_count == 1
+            push!(b, libSingular.ringorder_to_int(i.order))
             push!(b, 0)
             push!(b, 0)
             push!(b, 0)
          else
             error("more than one ordering c/C specified")
          end
+      elseif i.order == ringorder_s || i.order == ringorder_S
+         push!(b, libSingular.ringorder_to_int(i.order))
+         push!(b, i.size) # blk0 and
+         push!(b, i.size) # blk1 set to syz_comp for ringorder_s
+         push!(b, 0)
+      elseif i.order == ringorder_a
+         push!(b, libSingular.ringorder_to_int(i.order))
+         push!(b, lastvar + 1)
+         push!(b, min(lastvar + length(i.weights), nvars))
+         push!(b, length(i.weights))   # might be more weights than needed
+         for j in i.weights
+            push!(b, j)
+         end         
       else
-         blocksize = i.blocksize
-         if i.order == Singular.ringorder_wp || i.order == Singular.ringorder_ws ||
-            i.order == Singular.ringorder_Wp || i.order == Singular.ringorder_Ws
-            @assert blocksize > 0 && length(i.weights) == blocksize
-         elseif i.order == Singular.ringorder_M
-            @assert blocksize > 0 && length(i.weights) == blocksize*blocksize
-         elseif i.order == Singular.ringorder_lp || i.order == Singular.ringorder_ls ||
-                i.order == Singular.ringorder_rp || i.order == Singular.ringorder_rs ||
-                i.order == Singular.ringorder_dp || i.order == Singular.ringorder_ds ||
-                i.order == Singular.ringorder_Dp || i.order == Singular.ringorder_Ds
+         blksize = i.size
+         if _is_weighted_ordering(i.order)
+            @assert blksize > 0 && length(i.weights) == blksize
+         elseif i.order == ringorder_M
+            @assert blksize > 0 && length(i.weights) == blksize*blksize
+         elseif _is_basic_ordering(i.order)
             @assert length(i.weights) == 0
-            # dp() does one variable
-            if blocksize < 1
-               blocksize = 1
-            end
-            # unless it is at the end, in which case it consumes all remaining variables 
-            if l == length(ord.data)
-               if nvars - offset >= blocksize
-                  blocksize = nvars - offset
-               else
-                  error("mismatch of number of vars (", nvars, ") and ordering")
+            @assert blksize >= 0
+            # consume all remaining variables when succeeded by only C,c,S,s,IS
+            at_end = true
+            for ll in l+1:length(ord.data)
+               o = ord.data[ll].order
+               if o != ringorder_C && o != ringorder_c && o != ringorder_S &&
+                                      o != ringorder_s && o != ringorder_IS
+                  at_end = false
+                  break
                end
             end
+            if at_end
+               blksize = max(blksize, nvars - lastvar)
+            end
          else
-            error("unknown ordering specified")
+            error("unknown ordering $(i.order)")
          end
-         push!(b, Singular.libSingular.ringorder_to_int(i.order))
-         push!(b, offset + 1)
-         offset += blocksize
-         push!(b, offset)
+         push!(b, libSingular.ringorder_to_int(i.order))
+         push!(b, lastvar + 1)
+         lastvar += blksize
+         push!(b, lastvar)
          push!(b, length(i.weights))
          for j in i.weights
             push!(b, j)
@@ -1375,14 +1494,14 @@ function serialize_ordering(nvars::Int, ord::sordering)
       end
    end
 
-   if nvars != offset
-      error("mismatch of number of vars (", nvars, ") and ordering (", offset, " vars)")
+   if nvars != lastvar
+      error("mismatch of number of variables (", nvars, ") and ordering (", lastvar, ")")
    end
 
    # add order C if none exists
-   if c_count == 0
+   if cC_count == 0
       b[1] += 1
-      push!(b, Singular.libSingular.ringorder_to_int(Singular.ringorder_C))
+      push!(b, libSingular.ringorder_to_int(ringorder_C))
       push!(b, 0)
       push!(b, 0)
       push!(b, 0)
@@ -1391,36 +1510,79 @@ function serialize_ordering(nvars::Int, ord::sordering)
    return b
 end
 
+function deserialize_ordering(b::Vector{Cint})
+   off = 0
+   nblocks = b[off+=1]
+   data = sorder_block[]
+   for i in 1:nblocks
+      o = libSingular.ringorder_from_int(b[off+=1])
+      blk0 = b[off+=1]
+      blk1 = b[off+=1]
+      nweights = b[off+=1]
+      weights = Int.(b[(off+1):(off+nweights)])
+      off += nweights
+      blksize = blk1 - blk0 + 1
+      if _is_basic_ordering(o)
+         @assert nweights == 0
+         push!(data, sorder_block(o, blksize, Int[]))
+      elseif _is_weighted_ordering(o) || o == ringorder_M || o == ringorder_a
+         @assert nweights > 0
+         @assert nweights == (o == ringorder_M ? blksize*blksize : blksize)
+         push!(data, sorder_block(o, blksize, weights))
+      elseif o == ringorder_C || o == ringorder_c || o == ringorder_S
+         @assert nweights == 0
+         push!(data, sorder_block(o, 0, Int[]))
+      elseif o == ringorder_s
+         push!(data, sorder_block(o, blk0, Int[]))         
+      else
+         error("unknown ordering $(i.order)")
+      end
+    end
+    return sordering(data)
+end
+
+
 ###############################################################################
 #
 #   PolynomialRing constructor
 #
 ###############################################################################
 
-# keyword arguments do not participate in dispatch, hence this nonsense
-function PolynomialRing(R::Union{Ring, Field}, s::Array{String, 1};
-                        ordering = :degrevlex, ordering2::Symbol = :comp1min,
-                        cached::Bool = true, degree_bound::Int = 0)
+function _PolynomialRing(R, s::Array{String, 1}, ordering, ordering2, cached, degree_bound)
    S = [Symbol(v) for v in s]
    T = elem_type(R)
    if isa(ordering, Symbol)
-      parent_obj = PolyRing{T}(R, S, ordering, cached, sym2ringorder[ordering],
-                               sym2ringorder[ordering2], degree_bound)
+      ord1 = sym2ringorder[ordering]
+      ord2 = sym2ringorder[ordering2]
+      if (Int(ord1 == ringorder_c || ord1 == ringorder_C) +
+          Int(ord2 == ringorder_c || ord2 == ringorder_C) != 1)
+         error("ordering from symbol requires exactly one module ordering")
+      end
+      fancy_ordering = sordering([sorder_block(ord1, 0, Int[])])
+      if ord2 != ringorder_C
+         push!(fancy_ordering.data, sorder_block(ord2, 0, Int[]))
+      end
+   elseif isa(ordering, sordering)
+      fancy_ordering = ordering
    else
-      parent_obj = PolyRing{T}(R, S, ordering, cached, degree_bound)      
+      error("ordering must be a Symbol or an sordering")
    end
+   parent_obj = PolyRing{T}(R, S, fancy_ordering, cached, degree_bound)
    return tuple(parent_obj, gens(parent_obj))
 end
 
+# keyword arguments do not participate in dispatch
+function PolynomialRing(R::Union{Ring, Field}, s::Array{String, 1};
+                        ordering = :degrevlex, ordering2::Symbol = :comp1min,
+                        cached::Bool = true, degree_bound::Int = 0)
+   return _PolynomialRing(R, s, ordering, ordering2, cached, degree_bound)
+end
+
 function PolynomialRing(R::Nemo.Ring, s::Array{String, 1}; cached::Bool = true,
-      ordering::Symbol = :degrevlex, ordering2::Symbol = :comp1min,
+      ordering = :degrevlex, ordering2::Symbol = :comp1min,
       degree_bound::Int = 0)
-   S = CoefficientRing(R)
-   U = [Symbol(v) for v in s]
-   T = elem_type(S)
-   parent_obj = PolyRing{T}(S, U, ordering, cached, sym2ringorder[ordering],
-         sym2ringorder[ordering2], degree_bound)
-   return tuple(parent_obj, gens(parent_obj))
+   R = CoefficientRing(R)
+   return _PolynomialRing(R, s, ordering, ordering2, cached, degree_bound)
 end
 
 macro PolynomialRing(R, s, n, o)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1313,7 +1313,7 @@ Ws_order(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_Ws, v)
 function M_order(m::Matrix{Int}, checked::Bool = true)
    (nr, nc) = size(m)
    nr > 0 && nr == nc || "weight matrix must be square"
-   !checked || !iszero(Singular.Nemo.det(Singular.Nemo.matrix(Singular.Nemo.ZZ, m))) || "weight matrix must nonsingular"
+   !checked || !iszero(Singular.Nemo.det(Singular.Nemo.matrix(Singular.Nemo.ZZ, m))) || error("weight matrix must nonsingular")
    return sordering([sorder_block(Singular.ringorder_M, nr, vec(transpose(m)))])
 end
 

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1315,21 +1315,21 @@ function _is_weighted_ordering(t::libSingular.rRingOrder_t)
 end
 
 function _basic_ordering(t::libSingular.rRingOrder_t, size::Int)
-   size >= 0 || error("block size must be nonnegative")
+   size >= 0 || throw(ArgumentError("block size must be nonnegative"))
    return sordering([sorder_block(t, size, Int[])])
 end
 
 function _global_weighted_ordering(t::libSingular.rRingOrder_t, v::Vector{Int})
    len = length(v)
-   len > 0 || error("weight vector must be non-empty")
-   all(x->x>0, v) || error("all weights must be positive") 
+   len > 0 || throw(ArgumentError("weight vector must be non-empty"))
+   all(x->x>0, v) || throw(ArgumentError("all weights must be positive"))
    return sordering([sorder_block(t, len, v)])
 end
 
 function _local_weighted_ordering(t::libSingular.rRingOrder_t, v::Vector{Int})
    len = length(v)
-   len > 0 || error("weight vector must be non-empty")
-   v[1] != 0 || error("first weight must be nonzero")
+   len > 0 || throw(ArgumentError("weight vector must be non-empty"))
+   v[1] != 0 || throw(ArgumentError("first weight must be nonzero"))
    return sordering([sorder_block(t, len, v)])
 end
 
@@ -1444,19 +1444,24 @@ weights into the ordering matrix.
 ordering_a(w::Vector{Int}) = sordering([sorder_block(ringorder_a, 0, w)])
 
 @doc Markdown.doc"""
-    ordering_M(m::Matrix{Int}, checked::Bool = true)
+    ordering_M(m::Matrix{Int}; checked::Bool = true)
 
 Represents a block of variables with a general matrix ordering.
 The matrix `m` is expected to be invertible, and this is checked by default.
 """
-function ordering_M(m::Matrix{Int}, checked::Bool = true)
+function ordering_M(m::Matrix{Int}; checked::Bool = true)
    (nr, nc) = size(m)
-   nr > 0 && nr == nc || error("weight matrix must be square")
-   !checked || !iszero(Nemo.det(Nemo.matrix(Nemo.ZZ, m))) || error("weight matrix must nonsingular")
+   nr > 0 && nr == nc || throw(ArgumentError("weight matrix must be square"))
+   !checked || !iszero(Nemo.det(Nemo.matrix(Nemo.ZZ, m))) || throw(ArgumentError("weight matrix must nonsingular"))
    return sordering([sorder_block(ringorder_M, nr, vec(transpose(m)))])
 end
 
-# these three can take a dummy int in singular, but they do nothing with it?
+function ordering_M(m::fmpz_mat, checked::Bool = true)
+   !checked || !iszero(Nemo.det(m)) || throw(ArgumentError("weight matrix must nonsingular"))
+   return ordering_M(Int.(m), checked = false)
+end
+
+# C, c, and S can take a dummy int in singular, but they do nothing with it?
 
 @doc Markdown.doc"""
     ordering_C()

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1327,21 +1327,122 @@ function _local_weighted_ordering(t::libSingular.rRingOrder_t, v::Vector{Int})
    return sordering([sorder_block(t, len, v)])
 end
 
+@doc Markdown.doc"""
+    ordering_lp(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+lexicographical ordering (:lex).
+"""
 ordering_lp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_lp, nvars)
+
+@doc Markdown.doc"""
+    ordering_rp(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+reverse lexicographical ordering (:revlex).
+"""
 ordering_rp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_rp, nvars)
+
+@doc Markdown.doc"""
+    ordering_dp(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+degree reverse lexicographical ordering (:degrevlex).
+"""
 ordering_dp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_dp, nvars)
+
+@doc Markdown.doc"""
+    ordering_Dp(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+degree lexicographical ordering (:deglex).
+"""
 ordering_Dp(nvars::Int = 1) = _basic_ordering(Singular.ringorder_Dp, nvars)
-ordering_wp(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_wp, v)
-ordering_Wp(v::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_Wp, v)
+
+@doc Markdown.doc"""
+    ordering_wp(w::Vector{Int})
+
+Represents a block of variables with the
+weighted reverse lexicographical ordering.
+The weight vector `w` is expected to consist of positive integers only.
+"""
+ordering_wp(w::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_wp, w)
+
+@doc Markdown.doc"""
+    ordering_Wp(w::Vector{Int})
+
+Represents a block of variables with the
+weighted lexicographical ordering.
+The weight vector is expected to consist of positive integers only.
+"""
+ordering_Wp(w::Vector{Int}) = _global_weighted_ordering(Singular.ringorder_Wp, w)
+
+@doc Markdown.doc"""
+    ordering_ls(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+negative lexicographical ordering (:neglex).
+"""
 ordering_ls(nvars::Int = 1) = _basic_ordering(Singular.ringorder_ls, nvars)
+
+@doc Markdown.doc"""
+    ordering_rs(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+negative reverse lexicographical ordering (:negrevlex).
+"""
 ordering_rs(nvars::Int = 1) = _basic_ordering(Singular.ringorder_rs, nvars)
+
+@doc Markdown.doc"""
+    ordering_ds(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+negative degree reverse lexicographical ordering (:negdegrevlex).
+"""
 ordering_ds(nvars::Int = 1) = _basic_ordering(Singular.ringorder_ds, nvars)
+
+@doc Markdown.doc"""
+    ordering_Ds(nvars::Int = 1)
+
+Represents a block of at least `nvars` variables with the
+negative degree reverse lexicographical ordering (:negdeglex).
+"""
 ordering_Ds(nvars::Int = 1) = _basic_ordering(Singular.ringorder_Ds, nvars)
-ordering_ws(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_ws, v)
-ordering_Ws(v::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_Ws, v)
 
-ordering_a(v::Vector{Int}) = sordering([sorder_block(ringorder_a, 0, v)])
+@doc Markdown.doc"""
+    ordering_ws(w::Vector{Int})
 
+Represents a block of variables with the
+general weighted reverse lexicographical ordering.
+The weight vector `w` is expected to have a nonzero first entry.
+"""
+ordering_ws(w::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_ws, w)
+
+@doc Markdown.doc"""
+    ordering_Ws(w::Vector{Int})
+
+Represents a block of variables with the
+general weighted lexicographical ordering.
+The weight vector `w` is expected to have a nonzero first entry.
+"""
+ordering_Ws(w::Vector{Int}) = _local_weighted_ordering(Singular.ringorder_Ws, w)
+
+@doc Markdown.doc"""
+    ordering_a(w::Vector{Int})
+
+Represents an extra weight vector that may precede any monomial ordering.
+An extra weight vector does not define a monomial ordering by itself: it can
+only be used in combination with other orderings to insert an extra line of
+weights into the ordering matrix.
+"""
+ordering_a(w::Vector{Int}) = sordering([sorder_block(ringorder_a, 0, w)])
+
+@doc Markdown.doc"""
+    ordering_M(m::Matrix{Int}, checked::Bool = true)
+
+Represents a block of variables with a general matrix ordering.
+The matrix `m` is expected to be invertible, and this is checked by default.
+"""
 function ordering_M(m::Matrix{Int}, checked::Bool = true)
    (nr, nc) = size(m)
    nr > 0 && nr == nc || error("weight matrix must be square")
@@ -1350,43 +1451,50 @@ function ordering_M(m::Matrix{Int}, checked::Bool = true)
 end
 
 # these three can take a dummy int in singular, but they do nothing with it?
+
+@doc Markdown.doc"""
+    ordering_C()
+
+Represents an ascending ordering on vector components `gen(1) < gen(2) < ...`.
+All monomial block orderings preceding the component ordering have higher
+precedence, and all succeeding monomial block orderings have lower precedence.
+It is not necessary to specify this ordering explicitly since it appended
+automatically to an ordering lacking a component specification.
+"""
 ordering_C(dummy::Int = 0) = _basic_ordering(Singular.ringorder_C, 0)
+
+@doc Markdown.doc"""
+    ordering_c()
+
+Represents a decending ordering on vector components `gen(1) > gen(2) > ...`.
+All monomial block orderings preceding the component ordering have higher
+precedence, and all succeeding monomial block orderings have lower precedence.
+"""
 ordering_c(dummy::Int = 0) = _basic_ordering(Singular.ringorder_c, 0)
+
 ordering_S(dummy::Int = 0) = _basic_ordering(Singular.ringorder_S, 0)
 ordering_s(syz_comp::Int = 0) = sordering([sorder_block(Singular.ringorder_s, syz_comp, Int[])])
 
+@doc Markdown.doc"""
+    *(a::sordering, b::sordering)
+
+Return the concatenation two orderings. Some simplification may take place,
+i.e. ordering_lp(2)*ordering_lp(3) may return ordering_lp(5)
+"""
 function Base.:*(a::sordering, b::sordering)
    return sordering(vcat(a.data, b.data))
 end
 
-function Base.:(==)(a::sordering, b::sordering)
-   if length(a.data) != length(b.data)
-      return false
-   end
-   for i in 1:length(a.data)
-      if a.data[i].order != b.data[i].order
-         return false
-      elseif a.data[i].size != b.data[i].size
-         return false
-      elseif a.data[i].weights != b.data[i].weights
-         return false
-      end
-   end
-   return true
-end
+isordering_symbolic(a::sordering) = isordering_symbolic_with_symbol(a)[1]
+ordering_as_symbol(a::sordering) = isordering_symbolic_with_symbol(a)[2]
 
-isordering_a_symbol(a::sordering) = isordering_a_symbol_with_symbol(a)[1]
-ordering_as_symbol(a::sordering) = isordering_a_symbol_with_symbol(a)[2]
-
-function isordering_a_symbol_with_symbol(a::sordering)
+function isordering_symbolic_with_symbol(a::sordering)
    if length(a.data) != 1 && length(a.data) != 2
       return (false, :unknown)
    end
-
    if length(a.data) == 2 && a.data[2].order != ringorder_C
       return (false, :unknown)
    end
-
    o = a.data[1].order
    if o == ringorder_lp
       return (true, :lex)
@@ -1413,9 +1521,9 @@ function isordering_a_symbol_with_symbol(a::sordering)
    elseif o == ringorder_Wp
       return (true, :weightedlex)
    elseif o == ringorder_ws
-      return (false, :negweightedrevlex)
+      return (false, :genweightedrevlex)
    elseif o == ringorder_Ws
-      return (false, :negweightedlex)
+      return (false, :genweightedlex)
    elseif o == ringorder_a
       return (false, :extraweight)
    elseif o == ringorder_M
@@ -1426,6 +1534,14 @@ function isordering_a_symbol_with_symbol(a::sordering)
       return (false, :comp1min)
    else
       return (false, :unknown)
+   end
+end
+
+function Base.iterate(a::sordering, state = 1)
+   if state > length(a.data)
+      return nothing
+   else
+      return sordering([a.data[state]]), state + 1
    end
 end
 
@@ -1453,10 +1569,11 @@ function serialize_ordering(nvars::Int, ord::sordering)
       elseif i.order == ringorder_a
          push!(b, libSingular.ringorder_to_int(i.order))
          push!(b, lastvar + 1)
-         push!(b, min(lastvar + length(i.weights), nvars))
-         push!(b, length(i.weights))   # might be more weights than needed
-         for j in i.weights
-            push!(b, j)
+         nweights = min(length(i.weights), nvars - lastvar)
+         push!(b, lastvar + nweights)
+         push!(b, length(i.weights))
+         for j in 1:nweights
+            push!(b, i.weights[j])
          end         
       else
          blksize = i.size

--- a/test/poly/PolyRing-test.jl
+++ b/test/poly/PolyRing-test.jl
@@ -77,6 +77,13 @@ end
       end
    end
 
+   @test_throws ArgumentError ordering_wp(Int[])
+   @test_throws ArgumentError ordering_wp([-1, 2])
+   @test_throws ArgumentError ordering_ws(Int[])
+   @test_throws ArgumentError ordering_ws([0, 1])
+   @test_throws ArgumentError ordering_M([1 2; 3 6])
+   @test_throws ArgumentError ordering_M([1 2 3; 3 6 7])
+
    R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
                                           ordering_M([1 2; 3 5])*ordering_dp())
    test_ordering(ordering(R), [:matrix, :degrevlex, :comp1min],
@@ -84,6 +91,19 @@ end
                               [Int[1, 2, 3, 5], Int[], Int[]])
    test_monomials([x1^3*x2^2*x4^3, x1^3*x2^2*x3^2, x1^3*x2^2, x1*x2^3, x1^3*x2,
       x1*x2^2, x1^2*x2*x3, x1^2*x2*x4, x2^2, x1*x2, x2, x1, x3, x4, one(R)])
+
+   t = [1 0 1 0; 0 1 0 -1; 1 0 0 1; 0 1 1 0]
+   t = ordering_M(Singular.Nemo.matrix(Singular.Nemo.ZZ, t))
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering = t)
+   test_ordering(ordering(R), [:matrix, :comp1min],
+                              [4, 0],
+                              [Int[1,0,1,0, 0,1,0,-1, 1,0,0,1, 0,1,1,0], Int[]])
+   test_monomials([x1^2*x2^2*x3^2, x1^2*x2*x3^2, x1^2*x3^2, x1^2*x3^2*x4,
+      x1*x2^2*x3^2, x1^2*x2*x3, x1*x3^2, x1*x3^2*x4, x1^2*x2^2, x2^2*x3^2*x4,
+      x1*x2*x3, x2*x3^2, x1*x2*x3*x4, x2*x3^2*x4, x1*x3, x3^2, x1*x3*x4,
+      x3^2*x4, x1^2*x4^2, x1*x3*x4^2, x3^2*x4^2, x1*x2^2, x2^2*x3, x2^2*x3*x4,
+      x1*x2, x2*x3, x1*x2*x4, x2*x3*x4, x1, x3, x1*x2*x4^2, x1*x4, x1*x4^2,
+      x2^2, x2^2*x4, x2, x2^2*x4^2, x2*x4, one(R), x2*x4^2, x4, x4^2])
 
 
    R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =

--- a/test/poly/PolyRing-test.jl
+++ b/test/poly/PolyRing-test.jl
@@ -26,7 +26,7 @@
    end
 end
 
-@testset "PolyRing.ordering" begin
+@testset "PolyRing.ordering.symbol" begin
    R, (x, y, z) = PolynomialRing(QQ, ["x", "y", "z"])
    I = Ideal(R, x+z, y+z)
    I.isGB = true
@@ -56,4 +56,111 @@ end
    S = fres(I, 0)
    M = S[2]
    @test string(M[1]) == "[-y-z,x+z]"
+end
+
+@testset "PolyRing.ordering.fancy" begin
+   function test_monomials(l)
+      for i in 2:length(l)
+         @test l[i-1] > l[i]
+         @test l[i] < l[rand(1:i-1)]
+      end
+   end
+
+   function test_ordering(o, s, z, w)
+      @test length(o) == length(s)
+      j = 0
+      for i in o
+         j += 1
+         @test s[j] == ordering_as_symbol(i)
+         @test z[j] == ordering_size(i)
+         @test w[j] == ordering_weights(i)
+      end
+   end
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                          ordering_M([1 2; 3 5])*ordering_dp())
+   test_ordering(ordering(R), [:matrix, :degrevlex, :comp1min],
+                              [2, 2, 0],
+                              [Int[1, 2, 3, 5], Int[], Int[]])
+   test_monomials([x1^3*x2^2*x4^3, x1^3*x2^2*x3^2, x1^3*x2^2, x1*x2^3, x1^3*x2,
+      x1*x2^2, x1^2*x2*x3, x1^2*x2*x4, x2^2, x1*x2, x2, x1, x3, x4, one(R)])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                             ordering_Wp([1, 2])*ordering_rp())
+   test_ordering(ordering(R), [:weightedlex, :revlex, :comp1min],
+                              [2, 2, 0],
+                              [Int[1, 2], Int[], Int[]])
+   test_monomials([x2^3, x1*x2^2, x1^2*x2, x2^2*x4, x2^2*x3, x2^2, x1^3,
+      x1*x2*x4, x1*x2*x3, x1*x2, x1^2*x4, x1^2*x3, x1^2, x2*x4^2, x2*x3*x4,
+      x2*x4, x2*x3^2, x2*x3, x2, x1*x4^2, x1*x3*x4, x1*x4, x1*x3^2, x1*x3,
+      x1, x4^3, x3*x4^2, x4^2, x3^2*x4, x3*x4, x4, x3^3, x3^2, x3, one(R)])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                            ordering_rs(2)*ordering_wp([1, 2]))
+   test_ordering(ordering(R), [:negrevlex, :weightedrevlex, :comp1min],
+                              [2, 2, 0],
+                              [Int[], Int[1, 2], Int[]])
+   test_monomials([x4^3, x3*x4^2, x3^2*x4, x4^2, x3^3, x3*x4, x3^2, x4, x3,
+      one(R), x1*x4^2, x1*x3*x4, x1*x3^2, x1*x4, x1*x3, x1, x1^2*x4, x1^2*x3,
+      x1^2, x1^3, x2*x4^2, x2*x3*x4, x2*x3^2, x2*x4, x2*x3, x2, x1*x2*x4,
+      x1*x2*x3, x1*x2, x1^2*x2, x2^2*x4, x2^2*x3, x2^2, x1*x2^2, x2^3])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                            ordering_ls(2)*ordering_ws([1, 2]))
+   test_ordering(ordering(R), [:neglex, :negweightedrevlex, :comp1min],
+                              [2, 2, 0],
+                              [Int[], Int[1, 2], Int[]])
+   test_monomials([one(R), x3, x3^2, x4, x3^3, x3*x4, x3^2*x4, x4^2, x3*x4^2,
+      x4^3, x2, x2*x3, x2*x3^2, x2*x4, x2*x3*x4, x2*x4^2, x2^2, x2^2*x3,
+      x2^2*x4, x2^3, x1, x1*x3, x1*x3^2, x1*x4, x1*x3*x4, x1*x4^2, x1*x2,
+      x1*x2*x3, x1*x2*x4, x1*x2^2, x1^2, x1^2*x3, x1^2*x4, x1^2*x2, x1^3])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                            ordering_Ws([1, 2])*ordering_lp(2))
+   test_ordering(ordering(R), [:negweightedlex, :lex, :comp1min],
+                              [2, 2, 0],
+                              [Int[1, 2], Int[], Int[]])
+   test_monomials([x3^3, x3^2*x4, x3^2, x3*x4^2, x3*x4, x3, x4^3, x4^2, x4,
+      one(R), x1*x3^2, x1*x3*x4, x1*x3, x1*x4^2, x1*x4, x1, x1^2*x3, x1^2*x4,
+      x1^2, x2*x3^2, x2*x3*x4, x2*x3, x2*x4^2, x2*x4, x2, x1^3, x1*x2*x3,
+      x1*x2*x4, x1*x2, x1^2*x2, x2^2*x3, x2^2*x4, x2^2, x1*x2^2, x2^3])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                                 ordering_Dp(2)*ordering_Ds(2))
+   test_ordering(ordering(R), [:deglex, :negdeglex, :comp1min],
+                              [2, 2, 0],
+                              [Int[], Int[], Int[]])
+   test_monomials([x1^3, x1^2*x2, x1*x2^2, x2^3, x1^2, x1^2*x3, x1^2*x4, x1*x2,
+      x1*x2*x3, x1*x2*x4, x2^2, x2^2*x3, x2^2*x4, x1, x1*x3, x1*x4, x1*x3^2,
+      x1*x3*x4, x1*x4^2, x2, x2*x3, x2*x4, x2*x3^2, x2*x3*x4, x2*x4^2, one(R),
+      x3, x4, x3^2, x3*x4, x4^2, x3^3, x3^2*x4, x3*x4^2, x4^3])
+
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                                                 ordering_ds())
+   test_ordering(ordering(R), [:negdegrevlex, :comp1min],
+                              [4, 0],
+                              [Int[], Int[]])
+   test_monomials([one(R), x1, x2, x3, x4, x1^2, x1*x2, x2^2, x1*x3, x2*x3,
+      x3^2, x1*x4, x2*x4, x3*x4, x4^2, x1^3, x1^2*x2, x1*x2^2, x2^3, x1^2*x3,
+      x1*x2*x3, x2^2*x3, x1*x3^2, x2*x3^2, x3^3, x1^2*x4, x1*x2*x4, x2^2*x4,
+      x1*x3*x4, x2*x3*x4, x3^2*x4, x1*x4^2, x2*x4^2, x3*x4^2, x4^3])
+
+   R, (x1, x2, x3, x4) = PolynomialRing(QQ, "x".*string.(1:4), ordering =
+                                      ordering_a([1, -1, 1, -1])*ordering_dp())
+   test_ordering(ordering(R), [:extraweight, :degrevlex, :comp1min],
+                              [4, 4, 0],
+                              [Int[1, -1, 1, -1], Int[], Int[]])
+   test_monomials([x1^3, x1^2*x3, x1*x3^2, x3^3, x1^3*x2, x1^2*x2*x3,
+      x1*x2*x3^2, x1^2, x1*x3, x3^2, x1^3*x2^2, x1^2*x2^2*x3, x1^2*x2,
+      x1*x2*x3, x2*x3^2, x1^2*x4, x1*x3*x4, x3^2*x4, x1, x3, x1^3*x2^3,
+      x1^2*x2^2, x1*x2^2*x3, x1^2*x2*x4, x1*x2*x3*x4, x1*x2, x2*x3, x1*x4,
+      x3*x4, one(R), x1^2*x2^3, x1^2*x2^2*x4, x1*x2^2, x2^2*x3, x1*x2*x4,
+      x2*x3*x4, x1*x4^2, x3*x4^2, x2, x4, x1*x2^3, x1*x2^2*x4, x1*x2*x4^2,
+      x2^2, x2*x4, x4^2, x2^3, x2^2*x4, x2*x4^2, x4^3])
 end

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -165,7 +165,7 @@ end
    end
    @test gen(R, 1) == x
 
-   @test ordering(R) == :degrevlex
+   @test ordering_as_symbol(R) == :degrevlex
    @test degree(x^2*y^3 + 1, 1) == 2
    @test degree(x^2*y^3 + 1, y) == 3
    @test degree(R(), 1) == -1

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -165,6 +165,7 @@ end
    end
    @test gen(R, 1) == x
 
+   @test isordering_symbolic(R)
    @test ordering_as_symbol(R) == :degrevlex
    @test degree(x^2*y^3 + 1, 1) == 2
    @test degree(x^2*y^3 + 1, y) == 3


### PR DESCRIPTION
goes with https://github.com/oscar-system/libsingular-julia/pull/26
This cannot be tried by anyone else atm because it requires a new libsingular-julia, but I would just put this out there for comments: this is approximately what it will look like. @wdecker @hannes14 
Note that this is a singular.jl-only change. Orderings will be much different in oscar.


Both the old `ordering=symbol` and the new `ordering=fancystuff` will be supported.

```julia
julia> PolynomialRing(QQ, map(i->"x"*string(i), 1:8), ordering = :negdegrevlex)[1]
Singular Polynomial Ring (QQ),(x1,x2,x3,x4,x5,x6,x7,x8),(ds(8),C)

julia> PolynomialRing(QQ, map(i->"x"*string(i), 1:8), ordering = ds_order())[1]
Singular Polynomial Ring (QQ),(x1,x2,x3,x4,x5,x6,x7,x8),(ds(8),C)
```

This seems to match original singular in behaviour

```julia
julia> a = M_order([1 2; 3 5])*lp_order(3)*wp_order([1, 2, 3])
M_order([1 2; 3 5]) * lp_order(3) * wp_order([1, 2, 3])

julia> PolynomialRing(QQ, "x".*string.(1:8), ordering = a)[1]
Singular Polynomial Ring (QQ),(x1,x2,x3,x4,x5,x6,x7,x8),(M(1,2,3,5),lp(3),wp(1,2,3),C)

julia> PolynomialRing(QQ, "x".*string.(1:9), ordering = a)[1]
ERROR: mismatch of number of vars (9) and ordering (8 vars)
Stacktrace:
 [1] error(::String, ::Int64, ::String, ::Int64, ::String)
   @ Base ./error.jl:42
 [2] serialize_ordering(nvars::Int64, ord::Singular.sordering)
   @ Singular ~/.julia/dev/Singular/src/poly/poly.jl:1292
 [3] PolyRing{n_Q}(R::Rationals, s::Vector{Symbol}, ord::Singular.sordering, cached::Bool, degree_bound::Int64)
   @ Singular ~/.julia/dev/Singular/src/poly/PolyTypes.jl:100
 [4] #PolynomialRing#45
   @ ~/.julia/dev/Singular/src/poly/poly.jl:1323 [inlined]
 [5] top-level scope
   @ REPL[4]:1
```

This also seems to match original singular in regards to variable counts.

```julia
julia> a = dp_order(3)*lp_order(3)
dp_order(3) * lp_order(3)

julia> PolynomialRing(QQ, "x".*string.(1:6), ordering = a)[1]
Singular Polynomial Ring (QQ),(x1,x2,x3,x4,x5,x6),(dp(3),lp(3),C)

julia> PolynomialRing(QQ, "x".*string.(1:7), ordering = a)[1]
Singular Polynomial Ring (QQ),(x1,x2,x3,x4,x5,x6,x7),(dp(3),lp(4),C)

julia> PolynomialRing(QQ, "x".*string.(1:5), ordering = a)[1]
ERROR: mismatch of number of vars (5) and ordering
Stacktrace:
 [1] error(::String, ::Int64, ::String)
   @ Base ./error.jl:42
 [2] serialize_ordering(nvars::Int64, ord::Singular.sordering)
   @ Singular ~/.julia/dev/Singular/src/poly/poly.jl:1274
 [3] PolyRing{n_Q}(R::Rationals, s::Vector{Symbol}, ord::Singular.sordering, cached::Bool, degree_bound::Int64)
   @ Singular ~/.julia/dev/Singular/src/poly/PolyTypes.jl:100
 [4] #PolynomialRing#45
   @ ~/.julia/dev/Singular/src/poly/poly.jl:1323 [inlined]
 [5] top-level scope
   @ REPL[8]:1
```

Finally, I will probably opt to catch bad input as soon as possible.

```julia
julia> M_order([1 2; 3 6])
ERROR: weight matrix must nonsingular
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] M_order(m::Matrix{Int64}, checked::Bool)
   @ Singular ~/.julia/dev/Singular/src/poly/poly.jl:1229
 [3] M_order(m::Matrix{Int64})
   @ Singular ~/.julia/dev/Singular/src/poly/poly.jl:1227
 [4] top-level scope
   @ REPL[2]:1

```