### PR TITLE
Move base_ring to start of our structs

### DIFF
--- a/src/ideal/IdealTypes.jl
+++ b/src/ideal/IdealTypes.jl
@@ -19,16 +19,14 @@ mutable struct IdealSet{T <: Nemo.RingElem} <: Set
 end
 
 mutable struct sideal{T <: Nemo.RingElem} <: Module{T}
-   ptr::libSingular.ideal_ptr
    base_ring::PolyRing
+   ptr::libSingular.ideal_ptr
    isGB::Bool
 
    function sideal{T}(R::PolyRing, ids::spoly...) where T
       n = length(ids)
       id = libSingular.idInit(Cint(n),1)
-      z = new(id, R, false)
-      R.refcount += 1
-      finalizer(_sideal_clear_fn, z)
+      z = sideal{T}(R, id)
       for i = 1:n
          p = libSingular.p_Copy(ids[i].ptr, R.ptr)
          libSingular.setindex_internal(id, p, Cint(i - 1))
@@ -37,7 +35,7 @@ mutable struct sideal{T <: Nemo.RingElem} <: Module{T}
    end
 
    function sideal{T}(R::PolyRing, id::libSingular.ideal_ptr) where T
-      z = new(id, R, false)
+      z = new(R, id, false)
       R.refcount += 1
       finalizer(_sideal_clear_fn, z)
       return z

--- a/src/module/ModuleTypes.jl
+++ b/src/module/ModuleTypes.jl
@@ -20,12 +20,12 @@ mutable struct FreeMod{T <: Nemo.RingElem} <: Module{T}
 end
 
 mutable struct svector{T <: Nemo.RingElem} <: Nemo.ModuleElem{T}
+   base_ring::PolyRing
    ptr::libSingular.poly_ptr # not really a polynomial
    rank::Int
-   base_ring::PolyRing
 
    function svector{T}(R::PolyRing, r::Int, p::libSingular.poly_ptr) where T
-      z = new(p, r, R)
+      z = new(R, p, r)
       R.refcount += 1
       finalizer(_svector_clear_fn, z)
       return z
@@ -71,12 +71,12 @@ mutable struct ModuleClass{T <: Nemo.RingElem} <: Set
 end
 
 mutable struct smodule{T <: Nemo.RingElem} <: Module{T}
-   ptr::libSingular.ideal_ptr # ideal and module types are the same in Singular
    base_ring::PolyRing
+   ptr::libSingular.ideal_ptr # ideal and module types are the same in Singular
    isGB::Bool
 
    function smodule{T}(R::PolyRing, m::libSingular.ideal_ptr) where T
-      z = new(m, R, false)
+      z = new(R, m, false)
       R.refcount += 1
       finalizer(_smodule_clear_fn, z)
       return z

--- a/src/resolution/ResolutionTypes.jl
+++ b/src/resolution/ResolutionTypes.jl
@@ -19,14 +19,14 @@ mutable struct ResolutionSet{T <: Nemo.RingElem} <: Set
 end
 
 mutable struct sresolution{T <: Nemo.RingElem} <: Nemo.SetElem
+   base_ring::PolyRing
    ptr::libSingular.syStrategy_ptr
    minimal::Bool
-   base_ring::PolyRing
 
    # really takes a Singular module, which has type ideal
    function sresolution{T}(R::PolyRing, ptr::libSingular.syStrategy_ptr, minimal::Bool=false) where T
       R.refcount += 1
-      z = new(ptr, minimal, R)
+      z = new(R, ptr, minimal)
       finalizer(_sresolution_clear_fn, z)
       return z
    end


### PR DESCRIPTION
... corresponding to its placement in our constructors, where
it always comes first. This leads to more natural invocations of `new`.
