### PR TITLE
Update documentation with new links to AbstractAlgebra.

### DIFF
--- a/docs/src/integer.md
+++ b/docs/src/integer.md
@@ -31,12 +31,12 @@ all the integer ring parent object types belong to the abstract type `Ring`.
 
 ## Integer functionality
 
-Singular.jl integers implement the ring and possibly some parts of the Euclidean ring
-interfaces of AbstractAlgebra.jl.
+Singular.jl provides all the ring and possibly some parts of the Euclidean ring
+functionality of AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Singular integer ring.
 

--- a/docs/src/modn.md
+++ b/docs/src/modn.md
@@ -22,17 +22,17 @@ all the parent object types belong to the abstract type `Ring`.
 
 ## Integer mod $n$ functionality
 
-Singular.jl integers modulo $n$ implement the Ring and Residue Ring interfaces of
-AbstractAlgebra.jl.
+Singular.jl integers modulo $n$ provide all the AbstractAlgebra ring and residue ring
+functionality.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/residue_rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
 
 Parts of the Euclidean Ring interface may also be implemented, though Singular will
 report an error if division is meaningless (even after cancelling zero divisors).
 
-<https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Singular integers mod $n$
 ring and not already listed at the given links.

--- a/docs/src/modp.md
+++ b/docs/src/modp.md
@@ -22,12 +22,12 @@ all the parent object types belong to the abstract type `Field`.
 
 ## Integer mod $p$ functionality
 
-Singular.jl integers modulo $p$ implement the Field and Residue Ring interfaces of
-AbstractAlgebra.jl.
+Singular.jl integers modulo $p$ provides the field and residue ring functionality of
+AbstractAlgebra.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/fields.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/residue_rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/residue>
 
 Below, we describe the functionality that is specific to the Singular integers mod $p$
 field and not already listed at the given links.

--- a/docs/src/nemo.md
+++ b/docs/src/nemo.md
@@ -35,17 +35,17 @@ Specialised efficient wrappers exist for certain Nemo coefficient ring types.
 
 ## Nemo ring functionality
 
-Singular.jl foreign ring types implement the Ring interface and possibly the Field
-interface of AbstractAlgebra.jl.
+Singular.jl foreign ring types provide all of the AbstractAlgebra defined ring and
+some field functionality.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/ring>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/fields.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Parts of the Euclidean Ring interface may also be implemented, though Singular will
 report an error if division is meaningless (even after cancelling zero divisors).
 
-<https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Singular foreign ring
 interface that is not already listed at the given links.

--- a/docs/src/polynomial.md
+++ b/docs/src/polynomial.md
@@ -27,10 +27,10 @@ all the polynomial ring parent object types belong to the abstract type `MPolyRi
 
 ## Multivariate polynomial functionality
 
-Singular.jl polynomials implement the Multivariate Polynomial Ring interface of
-AbstractAlgebra.jl.
+Singular.jl polynomials provides all the Multivariate Polynomial Ring functionality
+described by AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/mpolynomial_rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial>
 
 In particular, Singular polynomials are sparse distributed, but do not have random
 access. Instead, they implement iterator access to terms. This is due to their storage
@@ -39,7 +39,7 @@ in a linked list, for efficient implementation of Groebner basis algorithms.
 Some polynomial rings may also implement part of the Euclidean Ring interface, where
 this is appropriate.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/euclidean.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/euclidean_interface>
 
 Below, we describe the functionality that is specific to the Singular multivariate
 polynomials that is not documented in the general multivariate interface.
@@ -110,7 +110,7 @@ but this can be extremely inefficient. For this purpose, Singular polynomials
 support construction using a build context, as described in the AbstractAlgebra
 documentation:
 
-<https://nemocas.github.io/AbstractAlgebra.jl/mpolynomial_rings.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/mpolynomial>
 
 **Examples**
 

--- a/docs/src/rational.md
+++ b/docs/src/rational.md
@@ -12,12 +12,12 @@ the unique field of rationals in Singular.
 
 ## Rational functionality
 
-The rationals in Singular.jl implement the Field interface defined by AbstractAlgebra.jl.
-They also implement the Fraction Field interface.
+The rationals in Singular.jl provide all functionality for fields and fraction fields
+described by AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/fields.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
-<https://nemocas.github.io/AbstractAlgebra.jl/fraction_fields.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/fraction>
 
 We describe here only the extra functionality provided by Singular that is not already
 described in those interfaces.

--- a/docs/src/transExt.md
+++ b/docs/src/transExt.md
@@ -21,9 +21,10 @@ all the parent object types belong to the abstract type `Field`.
 
 ## Function field functionality
 
-Singular.jl function fields implement the Field interface of AbstractAlgebra.jl.
+Singular.jl function fields provide all the functionality for fields described by
+AbstractAlgebra.jl.
 
-<https://nemocas.github.io/AbstractAlgebra.jl/fields.html>
+<https://nemocas.github.io/AbstractAlgebra.jl/latest/field>
 
 Below, we describe the functionality that is specific to Singular function field and not
 already listed at the given link.


### PR DESCRIPTION
This is the Singular counterpart to https://github.com/Nemocas/AbstractAlgebra.jl/pull/930

That PR needs to be merged before these links will be valid.