### PR TITLE
Fix Array constructor

### DIFF
--- a/src/module/vector.jl
+++ b/src/module/vector.jl
@@ -188,7 +188,7 @@ end
 #
 ###############################################################################
 
-function Array(v::svector{spoly{T}}) where T <: Nemo.RingElem
+function Base.Array(v::svector{spoly{T}}) where T <: Nemo.RingElem
    R = base_ring(v)
    GC.@preserve v R begin
       n = v.rank


### PR DESCRIPTION
We had `Singular.Array`, which is not what we intended... This constructor is used by `hash(V::svector, h::UInt)` so perhaps hashing for `svector` was broken before?!?