### PR TITLE
Rename variables only on the Singular side

### DIFF
--- a/src/MessyHacks.jl
+++ b/src/MessyHacks.jl
@@ -75,7 +75,7 @@ function all_symbols(R::N_AlgExtField)
 end
 
 function all_symbols(R::Union{N_FField, PolyRing})
-   return vcat(all_symbols(base_ring(R)), symbols(R))
+   return vcat(all_symbols(base_ring(R)), singular_symbols(R))
 end
 
 function isbad_name(x::String)

--- a/src/MessyHacks.jl
+++ b/src/MessyHacks.jl
@@ -62,20 +62,20 @@ end
 =#
 
 # return an array of all symbols used for printing objects in the ring
-function all_symbols(R::Nemo.Ring)
+function all_singular_symbols(R::Nemo.Ring)
    return Symbol[]
 end
 
-function all_symbols(R::N_GField)
-   return Symbol[R.S]
+function all_singular_symbols(R::N_GField)
+   return singular_symbols(R)
 end
 
-function all_symbols(R::N_AlgExtField)
-   return all_symbols(parent(R.minpoly))
+function all_singular_symbols(R::N_AlgExtField)
+   return all_singular_symbols(parent(R.minpoly))
 end
 
-function all_symbols(R::Union{N_FField, PolyRing})
-   return vcat(all_symbols(base_ring(R)), singular_symbols(R))
+function all_singular_symbols(R::Union{N_FField, PolyRing})
+   return vcat(all_singular_symbols(base_ring(R)), singular_symbols(R))
 end
 
 function isbad_name(x::String)

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -244,7 +244,8 @@ mutable struct N_GField <: Field
          if n == 1
             ptr = libSingular.nInitChar(libSingular.n_Zp, Ptr{Nothing}(p))
          else
-            gfinfo = GFInfo(Cint(p), Cint(n), pointer(Base.Vector{UInt8}(string(S)*"\0")))
+            ss = rename_symbol(string(S), "a")
+            gfinfo = GFInfo(Cint(p), Cint(n), pointer(Base.Vector{UInt8}(string(ss)*"\0")))
             GC.@preserve gfinfo begin
                ptr = libSingular.nInitChar(libSingular.n_GF, pointer_from_objref(gfinfo))
             end
@@ -294,15 +295,14 @@ mutable struct N_FField <: Field
    base_ring::Field
    refcount::Int
    S::Vector{Symbol}
-   singular_S::Vector{Symbol}
 
    function N_FField(F::Field, S::Vector{Symbol}, cached::Bool = true)
       return AbstractAlgebra.get_cached!(N_FFieldID, (F, S), cached) do
-         singular_S = rename_symbols(all_symbols(F), String.(S), "t")
-         v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in singular_S]
+         ss = rename_symbols(all_singular_symbols(F), String.(S), "t")
+         v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in ss]
          cf = libSingular.nCopyCoeff(F.ptr)
          ptr = libSingular.transExt_helper(cf, v)
-         d = new(ptr, F, 1, S, singular_S)
+         d = new(ptr, F, 1, S)
          finalizer(_Ring_finalizer, d)
          return d
       end::N_FField

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -294,13 +294,15 @@ mutable struct N_FField <: Field
    base_ring::Field
    refcount::Int
    S::Vector{Symbol}
+   singular_S::Vector{Symbol}
 
    function N_FField(F::Field, S::Vector{Symbol}, cached::Bool = true)
       return AbstractAlgebra.get_cached!(N_FFieldID, (F, S), cached) do
-         v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in S]
+         singular_S = rename_symbols(all_symbols(F), String.(S), "t")
+         v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in singular_S]
          cf = libSingular.nCopyCoeff(F.ptr)
          ptr = libSingular.transExt_helper(cf, v)
-         d = new(ptr, F, 1, S)
+         d = new(ptr, F, 1, S, singular_S)
          finalizer(_Ring_finalizer, d)
          return d
       end::N_FField

--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -22,6 +22,11 @@ end
 
 _characteristic(R::N_GField) = Int(libSingular.n_GetChar(R.ptr))
 
+function singular_symbols(R::N_GField)
+   degree(R) == 1 && return Symbol[]
+   GC.@preserve R return [Symbol(libSingular.n_ParameterName(0, R.ptr))]
+end
+
 @doc Markdown.doc"""
     degree(R::N_GField)
 
@@ -114,11 +119,8 @@ function AbstractAlgebra.expressify(a::n_GF; context = nothing)::Any
    end
 end
 
-function show(io::IO, n::n_GF)
-   libSingular.StringSetS("")
-   c = parent(n)
-   GC.@preserve n c libSingular.n_Write(n.ptr, c.ptr, false)
-   print(io, libSingular.StringEndS())
+function Base.show(io::IO, a::n_GF)
+   print(io, AbstractAlgebra.obj_to_string(a, context = io))
 end
 
 ###############################################################################
@@ -348,6 +350,6 @@ function FiniteField(p::Int, n::Int, S::String; cached=true)
    !Nemo.isprime(Nemo.fmpz(p)) && throw(DomainError(p, "p must be prime"))
    (n*log(p) >= 20*log(2) || p^n >= 2^16) &&
       throw(DomainError("p^n must be < 2^16"))
-   par = N_GField(p, n, rename_symbol(S, "a"), cached)
+   par = N_GField(p, n, Symbol(S), cached)
    return par, gen(par)
 end

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -43,7 +43,8 @@ function symbols(R::N_FField)
 end
 
 function singular_symbols(R::N_FField)
-   return R.singular_S
+   n = transcendence_degree(R)
+   GC.@preserve R return [Symbol(libSingular.n_ParameterName(Cint(i - 1), R.ptr)) for i = 1:n]
 end
 
 function deepcopy_internal(a::n_transExt, dict::IdDict)

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -42,6 +42,10 @@ function symbols(R::N_FField)
    return R.S
 end
 
+function singular_symbols(R::N_FField)
+   return R.singular_S
+end
+
 function deepcopy_internal(a::n_transExt, dict::IdDict)
    c = parent(a)
    GC.@preserve a c return c(libSingular.n_Copy(a.ptr, c.ptr))
@@ -373,7 +377,7 @@ function FunctionField(F::Singular.Field, S::Vector{String}; cached::Bool=true)
    isa(F, Rationals) || isa(F, N_ZpField) ||
              error("Only transcendental extensions of Q and Fp are supported.")
    isempty(S) && throw(ArgumentError("array must be non-empty"))
-   R = N_FField(F, rename_symbols(all_symbols(F), S, "t"), cached)
+   R = N_FField(F, Symbol.(S), cached)
    return tuple(R, transcendence_basis(R))
 end
 

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -53,7 +53,7 @@ function PolyRing{T}(R::Union{Ring, Field}, s::Vector{Symbol},
    deg_bound_fix = Int(libSingular.rGetExpSize(bitmask, Cint(nvars)))
    sord = serialize_ordering(nvars, ord)
    return get!(PolyRingID, (R, s, sord, deg_bound_fix)) do
-      ss = rename_symbols(all_symbols(R), String.(s), "x")
+      ss = rename_symbols(all_singular_symbols(R), String.(s), "x")
       v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in ss]
       r = libSingular.nCopyCoeff(R.ptr)
       ptr = libSingular.rDefault_wvhdl_helper(r, v, sord, bitmask)

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -32,12 +32,13 @@ mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
    base_ring::Union{Ring, Field}
    ord::sordering
    refcount::Int
+   S::Vector{Symbol}
 
    # take ownership of a ring ptr
-   function PolyRing{T}(r::libSingular.ring_ptr, R) where T
+   function PolyRing{T}(r::libSingular.ring_ptr, R, s::Vector{Symbol}=singular_symbols(r)) where T
       ord = Cint[]
       libSingular.rOrdering_helper(ord, r)
-      d = new(r, R, deserialize_ordering(ord), 1)
+      d = new(r, R, deserialize_ordering(ord), 1, s)
       finalizer(_PolyRing_clear_fn, d)
       return d
    end
@@ -52,11 +53,12 @@ function PolyRing{T}(R::Union{Ring, Field}, s::Vector{Symbol},
    deg_bound_fix = Int(libSingular.rGetExpSize(bitmask, Cint(nvars)))
    sord = serialize_ordering(nvars, ord)
    return get!(PolyRingID, (R, s, sord, deg_bound_fix)) do
-      v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in s]
+      ss = rename_symbols(all_symbols(R), String.(s), "x")
+      v = [pointer(Base.Vector{UInt8}(string(str)*"\0")) for str in ss]
       r = libSingular.nCopyCoeff(R.ptr)
       ptr = libSingular.rDefault_wvhdl_helper(r, v, sord, bitmask)
       @assert deg_bound_fix == Int(libSingular.rBitmask(ptr))
-      return PolyRing{T}(ptr, R)
+      return PolyRing{T}(ptr, R, s)
    end::PolyRing{T}
 end
 

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -106,6 +106,15 @@ end
 Return symbols for the generators of the polynomial ring $R$.
 """
 function symbols(R::PolyRing)
+   return R.S
+end
+
+function singular_symbols(r::libSingular.ring_ptr)
+   n = Int(libSingular.rVar(r))
+   return [Symbol(libSingular.rRingVar(Cshort(i - 1), r)) for i in 1:n]
+end
+
+function singular_symbols(R::PolyRing)
    GC.@preserve R return [Symbol(libSingular.rRingVar(Cshort(i - 1), R.ptr)) for i in 1:nvars(R)]
 end
 
@@ -1773,7 +1782,6 @@ end
 ###############################################################################
 
 function _PolynomialRing(R, s::Vector{String}, ordering, ordering2, cached, degree_bound)
-   S = rename_symbols(all_symbols(R), s, "x")
    T = elem_type(R)
    if isa(ordering, Symbol)
       ord1 = sym2ringorder[ordering]
@@ -1791,7 +1799,7 @@ function _PolynomialRing(R, s::Vector{String}, ordering, ordering2, cached, degr
    else
       error("ordering must be a Symbol or an sordering")
    end
-   parent_obj = PolyRing{T}(R, S, fancy_ordering, cached, degree_bound)
+   parent_obj = PolyRing{T}(R, Symbol.(s), fancy_ordering, cached, degree_bound)
    return tuple(parent_obj, gens(parent_obj))
 end
 

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -137,6 +137,16 @@ end
    R, x = PolynomialRing(F, s)
    @test String.(symbols(R)) == s
    @test String.(Singular.singular_symbols(R)) == ["t_1@2", "x", "t_2@1", "t_3@1", "t_1@3"]
+
+   F, a = FiniteField(3, 1, "\$")
+   @test String.(Singular.singular_symbols(F)) == []
+
+   F, a = FiniteField(3, 2, "\$")
+   s = ["a", "\$", "t[1]", "t[2]", "t[1]"]
+   R, x = PolynomialRing(F, s)
+   @test String.(Singular.singular_symbols(F)) == ["a"]
+   @test String.(symbols(R)) == s
+   @test String.(Singular.singular_symbols(R)) == ["a@1", "x", "t_1", "t_2", "t_1@1"]
 end
 
 @testset "spoly.manipulation" begin

--- a/test/poly/spoly-test.jl
+++ b/test/poly/spoly-test.jl
@@ -118,17 +118,25 @@ end
 end
 
 @testset "spoly.rename" begin
-   R, x = PolynomialRing(QQ, ["x[1]", "x[2]", "x[3]"])
-   @test map(String, symbols(R)) == ["x_1", "x_2", "x_3"]
+   s = ["x[1]", "x[2]", "x[3]"]
+   R, x = PolynomialRing(QQ, s)
+   @test String.(symbols(R)) == s
+   @test String.(Singular.singular_symbols(R)) == ["x_1", "x_2", "x_3"]
 
-   R, x = PolynomialRing(QQ, ["x[1][2]", "\$", "x[2][3]", "x[3][4]"])
-   @test map(String, symbols(R)) == ["x_1_2", "x", "x_2_3", "x_3_4"]
+   s = ["x[1][2]", "\$", "x[2][3]", "x[3][4]"]
+   R, x = PolynomialRing(QQ, s)
+   @test String.(symbols(R)) == s
+   @test String.(Singular.singular_symbols(R)) == ["x_1_2", "x", "x_2_3", "x_3_4"]
 
-   F, t = FunctionField(QQ, ["t[1]", "\$", "t[2]", "t[3]", "t[1]"])
-   @test map(String, symbols(F)) == ["t_1", "t", "t_2", "t_3", "t_1@1"]
+   s = ["t[1]", "\$", "t[2]", "t[3]", "t[1]"]
+   F, t = FunctionField(QQ, s)
+   @test String.(symbols(F)) == s
+   @test String.(Singular.singular_symbols(F)) == ["t_1", "t", "t_2", "t_3", "t_1@1"]
 
-   R, x = PolynomialRing(F, ["t[1]", "\$", "t[2]", "t[3]", "t[1]"])
-   @test map(String, symbols(R)) == ["t_1@2", "x", "t_2@1", "t_3@1", "t_1@3"]
+   s = ["t[1]", "\$", "t[2]", "t[3]", "t[1]"]
+   R, x = PolynomialRing(F, s)
+   @test String.(symbols(R)) == s
+   @test String.(Singular.singular_symbols(R)) == ["t_1@2", "x", "t_2@1", "t_3@1", "t_1@3"]
 end
 
 @testset "spoly.manipulation" begin


### PR DESCRIPTION
Hi! I understand that variable renaming is necessary due to Singular's parsing, however I also really do want to use fancy unicode for variable names :)

Here is a (rough) proposal to do the renaming only on the Singular side, so in Julia variables will be printed the way they are defined. Also the caching uses the variable names *before* renaming, so we can have
```julia
julia> PolynomialRing(QQ, ["α"])[1] === PolynomialRing(QQ, ["x"])[1]
false
```