### PR TITLE
lib4ti2: switch to BinaryWrappers.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
+BinaryWrappers = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ libsingular_julia_jll = "ae4fbd8f-ecdb-54f8-bbce-35570499b30e"
 
 [compat]
 AbstractAlgebra = "0.22.0"
+BinaryWrappers = "~0.1.1"
 CxxWrap = "0.11"
 Nemo = "0.27.0"
 RandomExtensions = "0.4.2"


### PR DESCRIPTION
This switches the lib4ti2_jll wrappers to a common scratchspace that is used by polymake as well.

Unfortunately this doesn't work as expected right now, somehow singular does not call the wrapper as expected, at least locally I got some error output from singular even though the testsuite still succeeded.

_Edit_: 
Github actions show the same messages but still succeeds with the Singular testuite:
```
call.Interpreter |    6      6
awk: cmd. line:1: fatal: cannot open file `sing4ti2.mar' for reading (No such file or directory)
    singular error: wrong range[2] in ideal/module _(1)
awk: cmd. line:1: fatal: cannot open file `sing4ti2.gra' for reading (No such file or directory)
    singular error: wrong range[2] in ideal/module _(1)
awk: cmd. line:1: fatal: cannot open file `sing4ti2.hil' for reading (No such file or directory)
    singular error: wrong range[2] in ideal/module _(1)
Test Summary: | Pass  Total
caller.Lib    |   28     28
```