### PR TITLE
Remove redundant isequal methods causing invalidations

### DIFF
--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -164,8 +164,6 @@ function ==(x::n_GF, y::n_GF)
    GC.@preserve x y return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_GF, y::n_GF) = (x == y)
-
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -184,8 +184,6 @@ function ==(x::n_Q, y::n_Q)
    GC.@preserve x y c return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_Q, y::n_Q) = (x == y)
-
 ###############################################################################
 #
 #   Ad hoc comparison
@@ -195,10 +193,6 @@ isequal(x::n_Q, y::n_Q) = (x == y)
 ==(x::n_Q, y::Integer) = (x ==  parent(x)(y))
 
 ==(x::Integer, y::n_Q) = (parent(y)(x) == y)
-
-isequal(x::n_Q, y::Integer) = (x == y)
-
-isequal(x::Integer, y::n_Q) = (x == y)
 
 isless(x::n_Q, y::Integer) = isless(x, parent(x)(y))
 

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -164,8 +164,6 @@ function ==(x::n_Z, y::n_Z)
    GC.@preserve x y c return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_Z, y::n_Z) = (x == y)
-
 ###############################################################################
 #
 #   Ad hoc comparison
@@ -178,10 +176,6 @@ isequal(x::n_Z, y::n_Z) = (x == y)
 
 ==(x::n_Z, y::Nemo.fmpz) = Nemo.fmpz(convert(BigInt, x)) == y
 ==(x::Nemo.fmpz, y::n_Z) = y == x
-
-isequal(x::n_Z, y::Integer) = (x == y)
-
-isequal(x::Integer, y::n_Z) = (x == y)
 
 isless(x::n_Z, y::Integer) = isless(x, parent(x)(y))
 

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -142,8 +142,6 @@ function ==(x::n_Zn, y::n_Zn)
    GC.@preserve x y c return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_Zn, y::n_Zn) = (x == y)
-
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -125,8 +125,6 @@ function ==(x::n_Zp, y::n_Zp)
    GC.@preserve x y c return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_Zp, y::n_Zp) = (x == y)
-
 ###############################################################################
 #
 #   Ad hoc comparison

--- a/src/number/n_algExt.jl
+++ b/src/number/n_algExt.jl
@@ -168,8 +168,6 @@ function ==(x::n_algExt, y::n_algExt)
    GC.@preserve x y c return libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_algExt, y::n_algExt) = (x == y)
-
 ###############################################################################
 #
 #   Powering

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -218,8 +218,6 @@ function ==(x::n_transExt, y::n_transExt)
    GC.@preserve x y c return c == parent(y) && libSingular.n_Equal(x.ptr, y.ptr, c.ptr)
 end
 
-isequal(x::n_transExt, y::n_transExt) = (x == y)
-
 ###############################################################################
 #
 #   Powering


### PR DESCRIPTION
The Julia stdlib defines `isequal(x,y) = x==y` as default method, so no
need to provide such methods on our own.

At the same time, some of these methods we provided introduced method
invalidations (specifically those were one argument is generic / of type
Integer). These invalidations make the new native code caching feature
in Julia 1.9 much less useful for Oscar.

Moreover,
