### PR TITLE
fix important(?) typo

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -81,7 +81,7 @@ export ZZ, QQ, FiniteField, FunctionField, CoefficientRing, Fp
 const libsingular = Singular_jll.libsingular
 const binSingular = Singular_jll.Singular_path
 
-const libsingula_julia = libsingular_julia_jll.libsingular_julia
+const libsingular_julia = libsingular_julia_jll.libsingular_julia
 
 const libflint = Nemo.libflint
 const libantic = Nemo.libantic


### PR DESCRIPTION
while working on another PR, i found this.
Since there is no use of `libsingula_julia`, I suppose this is a typo.
Consequences of fixing this are unknown to me.