### PR TITLE
Move test dependencies to `test/Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,9 +25,3 @@ RandomExtensions = "0.4.2"
 Singular_jll = "~403.201.001"
 julia = "1.6"
 libsingular_julia_jll = "~0.30.0"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 
 [compat]
 Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
-using Documenter, Singular
+using Documenter
+using Singular
 
 makedocs(
          format = Documenter.HTML(),

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,14 +10,13 @@ import Singular.Nemo
 
 using Test
 
-include("../test/number-test.jl")
-include("../test/poly-test.jl")
-include("../test/ideal-test.jl")
-include("../test/map-test.jl")
-include("../test/matrix-test.jl")
-include("../test/resolution-test.jl")
-include("../test/module-test.jl")
-include("../test/call_interpreter-test.jl")
-include("../test/caller-test.jl")
-include("../test/libsingular-test.jl")
-
+include("number-test.jl")
+include("poly-test.jl")
+include("ideal-test.jl")
+include("map-test.jl")
+include("matrix-test.jl")
+include("resolution-test.jl")
+include("module-test.jl")
+include("call_interpreter-test.jl")
+include("caller-test.jl")
+include("libsingular-test.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
 using Singular
 
-using Random: Random, MersenneTwister
+using Singular.Random: Random, MersenneTwister
 const rng = MersenneTwister()
 
-using RandomExtensions: make
+using Singular.RandomExtensions: make
 
-import AbstractAlgebra
-import Nemo
+import Singular.AbstractAlgebra
+import Singular.Nemo
 
 using Test
 


### PR DESCRIPTION
See https://github.com/oscar-system/Oscar.jl/issues/2385.

Additionally does the same improvements to docs/Project.toml.