### PR TITLE
detect NULL-Ptr (to avoid seg-fault)

### DIFF
--- a/src/libsingular/coeffs.jl
+++ b/src/libsingular/coeffs.jl
@@ -66,17 +66,17 @@ const nemoNumberID = Base.Dict{UInt, live_cache}()
 
 function julia(cf::coeffs_ptr)
    ptr = get_coeff_data(cf)
-   @assert reinterpret(Int, ptr) != 0
+   @assert ptr != C_NULL
    return unsafe_pointer_to_objref(ptr)
 end
 
 function julia(p::Ptr{Cvoid})
-    @assert reinterpret(Int, p) != 0
+    @assert p != C_NULL
     return unsafe_pointer_to_objref(p)
 end
 
 function number_pop!(D::Base.Dict{UInt, live_cache}, ptr::Ptr{Cvoid})
-    @assert reinterpret(Int, ptr) != 0
+    @assert ptr != C_NULL
     iptr = reinterpret(UInt, ptr) >> 24
     if haskey(D, iptr)
         val = D[iptr]
@@ -91,7 +91,7 @@ end
 # j alive because it is going into nemoNumberID
 function number(j::T) where {T <: Nemo.RingElem}
     ptr = pointer_from_objref(j)
-    @assert reinterpret(Int, ptr) != 0
+    @assert ptr != C_NULL
     iptr = reinterpret(UInt, ptr) >> 24
     if !haskey(nemoNumberID, iptr)
        nemoNumberID[iptr] = live_cache(0, Array{Nemo.RingElem}(undef, 64))

--- a/src/libsingular/coeffs.jl
+++ b/src/libsingular/coeffs.jl
@@ -66,14 +66,17 @@ const nemoNumberID = Base.Dict{UInt, live_cache}()
 
 function julia(cf::coeffs_ptr)
    ptr = get_coeff_data(cf)
+   @assert reinterpret(Int, ptr) != 0
    return unsafe_pointer_to_objref(ptr)
 end
 
 function julia(p::Ptr{Cvoid})
+    @assert reinterpret(Int, p) != 0
     return unsafe_pointer_to_objref(p)
 end
 
 function number_pop!(D::Base.Dict{UInt, live_cache}, ptr::Ptr{Cvoid})
+    @assert reinterpret(Int, ptr) != 0
     iptr = reinterpret(UInt, ptr) >> 24
     if haskey(D, iptr)
         val = D[iptr]
@@ -88,6 +91,7 @@ end
 # j alive because it is going into nemoNumberID
 function number(j::T) where {T <: Nemo.RingElem}
     ptr = pointer_from_objref(j)
+    @assert reinterpret(Int, ptr) != 0
     iptr = reinterpret(UInt, ptr) >> 24
     if !haskey(nemoNumberID, iptr)
        nemoNumberID[iptr] = live_cache(0, Array{Nemo.RingElem}(undef, 64))


### PR DESCRIPTION
kind of fixes #2435 by giging an error (uncomprehensible) instead of a seg-fault.
"Proper" fix is to raise an "not-implemented" error in the Singular kernel when factory is called (should be called) and is not available.
Dream fix would be to call back into Oscar then...
Other "fix" would be to translate to an AnticNumberField in this example, since that translates to Singular