### PR TITLE
Divrem fixes

### DIFF
--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -751,7 +751,7 @@ end
 
 Computes a division with remainder of the generators of `I` by
 the generators of `G`. Returns a tuple (Quo, Rem, U) where
-  `Matrix(I)*U = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
+`Matrix(I)*Matrix(U) = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
 and `Rem = normalform(I, G)`. `U` is a diagonal matrix of units differing
 from the identity matrix only for local ring orderings.
 """
@@ -764,7 +764,7 @@ function divrem(I::sideal{S}, G::sideal{S}; complete_reduction::Bool = false) wh
                                                                    false, true, R.ptr)
    libSingular.set_option("OPT_REDSB",old_redsb)
    libSingular.set_option("OPT_REDTAIL",old_redtail)
-   return (smodule{S}(R,ptr_T), sideal{S}(R,ptr_Rest), smatrix{S}(R,ptr_U))
+   return (smodule{S}(R,ptr_T), sideal{S}(R,ptr_Rest), smodule{S}(R,ptr_U))
 end
 
 ###############################################################################

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -200,7 +200,7 @@ end
 
 Computes a division with remainder of the generators of `I` by
 the generators of `G`. Returns a tuple (Quo, Rem, U) where
-  `Matrix(I)*U = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
+`Matrix(I)*MAtrix(U) = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
 and `Rem = normalform(I, G)`. `U` is a diagonal matrix of units differing
 from the identity matrix only for local ring orderings.
 """
@@ -213,7 +213,7 @@ function divrem(I::smodule{S}, G::smodule{S}; complete_reduction::Bool = false) 
                                                                    false, true, R.ptr)
    libSingular.set_option("OPT_REDSB",old_redsb)
    libSingular.set_option("OPT_REDTAIL",old_redtail)
-   return (smodule{S}(R,ptr_T), smodule{S}(R,ptr_Rest), smatrix{S}(R,ptr_U))
+   return (smodule{S}(R,ptr_T), smodule{S}(R,ptr_Rest), smodule{S}(R,ptr_U))
 end
 
 ###############################################################################

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -204,7 +204,7 @@ end
 
 Computes a division with remainder of the generators of `I` by
 the generators of `G`. Returns a tuple (Quo, Rem, U) where
-`Matrix(I)*MAtrix(U) = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
+`Matrix(I)*Matrix(U) = Matrix(G)*Matrix(Quo) + Matrix(Rem)`
 and `Rem = normalform(I, G)`. `U` is a diagonal matrix of units differing
 from the identity matrix only for local ring orderings.
 """

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -165,16 +165,20 @@ end
 ###############################################################################
 
 @doc raw"""
-    reduce(M::smodule, G::smodule)
+    reduce(M::smodule, G::smodule; complete_reduction::Bool = true)
 
 Return a submodule whose generators are the generators of $M$ reduced by the
 submodule $G$. The submodule $G$ need not be a Groebner basis. The returned
 submodule will have the same number of generators as $M$, even if they are zero.
 """
-function reduce(M::smodule, G::smodule)
+function reduce(M::smodule, G::smodule; complete_reduction::Bool = true)
    check_parent(M, G)
    R = base_ring(M)
-   ptr = GC.@preserve M G R libSingular.p_Reduce(M.ptr, G.ptr, R.ptr)
+   if complete_reduction
+      ptr = GC.@preserve M G R libSingular.p_Reduce(M.ptr, G.ptr, R.ptr)
+   else
+      ptr = GC.@preserve M G R libSingular.p_Reduce(M.ptr, G.ptr, R.ptr,1)
+   end
    return Module(R, ptr)
 end
 

--- a/test/ideal/sideal-test.jl
+++ b/test/ideal/sideal-test.jl
@@ -87,7 +87,7 @@ end
    f = (x^3+y^5)^2+x^2*y^7
    @test mult(std(@inferred jacobian_ideal(f))) == 46
    @test mult(std(Ideal(R, f))) == 6
-   
+
    R, (x, y) = polynomial_ring(QQ, ["x", "y"]; ordering= :lex)
    @test_throws ErrorException iszerodim(Ideal(R, x+y,x^2))
 end
@@ -684,7 +684,7 @@ end
                  1*x*z^14+6*x^2*y^4+3*z^24,
                  5*y^10*z^10*x+2*y^20*z^10+y^10*z^20+11*x^3])
 
-   @test ngens(std_hilbert(j, h, w, complete_reduction = true)) == 
+   @test ngens(std_hilbert(j, h, w, complete_reduction = true)) ==
          ngens(std(j, complete_reduction = true))
 end
 
@@ -693,4 +693,14 @@ end
    R, (H, S, C) = polynomial_ring(F, ["H", "S", "C"]; ordering = ordering_lp());
    I = Ideal(R,-e*H*S - m1*k*H*C + m1*C, -e*H*S - m2*k2*S*C + m2*C, e*H*S - b3*k3*C^2 + b3*C);
    @test dimension(std(I)) == 1
+end
+
+@testset "sideal.divrem and reduce" begin
+   R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+   a = Ideal(R,[x^3+y^3+x*y])
+   b = Ideal(R, [x])
+   q,r,u = divrem(a, b)
+   @test Singular.Matrix(a)*Singular.Matrix(u) == Singular.Matrix(b)*Singular.Matrix(q)+Singular.Matrix(r)
+   @test gens(reduce(a, b, complete_reduction=false))[1] ==y^3+x*y
+   @test gens(reduce(a, b, complete_reduction=true))[1] == y^3
 end

--- a/test/module/smodule-test.jl
+++ b/test/module/smodule-test.jl
@@ -294,3 +294,15 @@ end
    M.isGB = true
    @test hilbert_series(M,[1,1,1],[0,0]) == [1,0,-3,0,3,0,-1,0]
 end
+
+@testset "smodule.divrem and reduce" begin
+   R, (x, y) = polynomial_ring(QQ, ["x", "y"])
+   a = Singular.Module(R,vector(R, x^3+y^3+x*y, R(1)))
+   b = Singular.Module(R, vector(R, x, R(0)))
+   q,r,u = divrem(a, b)
+   @test Singular.Matrix(a)*Singular.Matrix(u) == Singular.Matrix(b)*Singular.Matrix(q)+Singular.Matrix(r)
+   r = reduce(a, b, complete_reduction=false)
+   @test r[1] == vector(R, y^3+x*y, R(1))
+   r = reduce(a, b, complete_reduction=true)
+   @test r[1] == vector(R, y^3, R(1))
+end


### PR DESCRIPTION
1. Fixes `divrem` to return module type elements for units (compatibility to `division`).
2. Adds kwarg `complete_reduction` to `reduce` for modules.
3. Adds tests for `divrem` and `reduce` for ideals and modules