### PR TITLE
CI: use concrete action version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,9 +47,9 @@ jobs:
       - name: "Cache artifacts"
         uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
       - name: "Run doctests"
@@ -79,7 +79,7 @@ jobs:
       - name: "Cache artifacts"
         uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - run: |
           julia --project=docs --color=yes -e '
             using Pkg

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Cache artifacts"
         uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Check treehash match"
         run: |
           julia --project --color=yes -e '


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/pull/2770 for Singular.jl. This is recommended by the [readme](https://github.com/julia-actions/julia-buildpkg#usage).