### PR TITLE
Use setdocmeta to simplify writing docstring examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,8 +59,9 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()
-            using Documenter: doctest
+            using Documenter: doctest, DocMeta
             using Singular
+            DocMeta.setdocmeta!(Singular, :DocTestSetup, :(using Singular); recursive = true)
             doctest(Singular)'
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
@@ -85,11 +86,6 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - run: |
-          julia --project=docs --color=yes -e '
-            using Documenter: doctest
-            using Singular
-            doctest(Singular)'
       - run: julia --project=docs --color=yes docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,14 @@
 using Documenter
 using Singular
 
+DocMeta.setdocmeta!(Singular, :DocTestSetup, :(using Singular); recursive = true)
+
 makedocs(
          format = Documenter.HTML(),
          sitename = "Singular.jl",
          modules = [Singular],
          clean = true,
-         doctest = false,
+         doctest = true,
          pages    = [
              "index.md",
              "Coefficient rings" => [

--- a/src/caller.jl
+++ b/src/caller.jl
@@ -406,7 +406,7 @@ is called "Top", and ring dependent objects are contained in their basering,
 which is returned as a dictionary.
 
 # Examples
-```jldoctest; setup = :(using Singular)
+```jldoctest
 julia> Singular.call_interpreter("bigint a = 42;");
 
 julia> a = Singular.lookup_library_symbol("Top", "a"); (a, typeof(a))


### PR DESCRIPTION
Also run doctests when building the docs
