### PR TITLE
adapt to array changes in julia nightly

### DIFF
--- a/deps/src/caller.cpp
+++ b/deps/src/caller.cpp
@@ -109,12 +109,7 @@ jl_value_t * intmat_to_jl_array(intvec * v)
 {
   int          rows = v->rows();
   int          cols = v->cols();
-#if (JULIA_VERSION_MAJOR * 100 + JULIA_VERSION_MINOR) >= 111
-  size_t dims[]{(size_t) rows, (size_t) cols};
-  jl_array_t * result = jl_alloc_array_nd(jl_int64_matrix_type, dims, 2);
-#else
   jl_array_t * result = jl_alloc_array_2d(jl_int64_matrix_type, rows, cols);
-#endif
   int64_t * result_ptr = jlcxx_array_data<int64_t>(result);
   for (int i = 0; i < rows; i++)
   {

--- a/deps/src/singular.cpp
+++ b/deps/src/singular.cpp
@@ -284,10 +284,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
 
     // get output
     jl_array_t * result = jl_alloc_array_1d(jl_array_any_type, 4);
-    jl_arrayset(result, err ? jl_true : jl_false, 0);
-    jl_arrayset(result, jl_cstr_to_string(singular_return.c_str()), 1);
-    jl_arrayset(result, jl_cstr_to_string(singular_error.c_str()), 2);
-    jl_arrayset(result, jl_cstr_to_string(singular_warning.c_str()), 3);
+    jl_array_ptr_set(result, 0, err ? jl_true : jl_false);
+    jl_array_ptr_set(result, 1, jl_cstr_to_string(singular_return.c_str()));
+    jl_array_ptr_set(result, 2, jl_cstr_to_string(singular_error.c_str()));
+    jl_array_ptr_set(result, 3, jl_cstr_to_string(singular_warning.c_str()));
 
     // restore old callbacks
     PrintS_callback = default_print;


### PR DESCRIPTION
~~This needs https://github.com/JuliaInterop/libcxxwrap-julia/pull/137 which is not released yet.~~
Also requires some parts of https://github.com/JuliaLang/julia/pull/52248 (depending on how this gets merged the `#if` can be removed again).

I removed an unused Int32 case from `jl_array_to_intvec`, this is only used with an explicit Int64 vector anyway.

Locally (on Linux) this works fine with julia 1.6.7, 1.9.4 and nightly with my julia PR and a custom libcxxwrap + cxxwrap.

~~Note that this branch was based on 0.19 instead of the latest master to allow testing with Oscar.~~ rebased on master.