### PR TITLE
Remove instance dispatches for `*_type`

### DIFF
--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -21,8 +21,6 @@ base_ring(I::sideal) = I.base_ring
 
 elem_type(::Type{IdealSet{spoly{T}}}) where T <: Nemo.RingElem = sideal{spoly{T}}
 
-elem_type(::IdealSet{spoly{T}}) where T <: Nemo.RingElem = sideal{spoly{T}}
-
 parent_type(::Type{sideal{spoly{T}}}) where T <: Nemo.RingElem = IdealSet{spoly{T}}
 
 @doc raw"""

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -20,8 +20,6 @@ base_ring(M::smatrix) = M.base_ring
 
 elem_type(::Type{matrix_space{T}}) where T <: AbstractAlgebra.RingElem = smatrix{T}
 
-elem_type(::matrix_space{T}) where T <: AbstractAlgebra.RingElem = smatrix{T}
-
 parent_type(::Type{smatrix{T}}) where T <: AbstractAlgebra.RingElem = matrix_space{T}
 
 function getindex(M::smatrix{T}, i::Int, j::Int) where T <: AbstractAlgebra.RingElem

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -13,8 +13,6 @@ base_ring(S::ModuleClass) = S.base_ring
 
 base_ring(I::smodule) = I.base_ring
 
-elem_type(::ModuleClass{T}) where T <: AbstractAlgebra.RingElem = smodule{T}
-
 elem_type(::Type{ModuleClass{T}}) where T <: AbstractAlgebra.RingElem = smodule{T}
 
 parent_type(::Type{smodule{T}}) where T <: AbstractAlgebra.RingElem = ModuleClass{T}

--- a/src/module/vector.jl
+++ b/src/module/vector.jl
@@ -12,8 +12,6 @@ base_ring(R::FreeMod) = R.base_ring
 
 base_ring(v::svector) = v.base_ring
 
-elem_type(::FreeMod{T}) where {T <: Nemo.RingElem} = svector{T}
-
 elem_type(::Type{FreeMod{T}}) where {T <: Nemo.RingElem} = svector{T}
 
 parent_type(::Type{svector{T}}) where {T <: Nemo.RingElem} = FreeMod{T}

--- a/src/number/n_unknown.jl
+++ b/src/number/n_unknown.jl
@@ -350,8 +350,8 @@ end
 elem_type(::Type{RingWrapper{S, T}}) where {S, T} = RingElemWrapper{S, T}
 elem_type(::Type{FieldWrapper{S, T}}) where {S, T} = FieldElemWrapper{S, T}
 
-parent_type(a::Type{RingElemWrapper{S, T}}) where {S, T} = RingWrapper{S, T}
-parent_type(a::Type{FieldElemWrapper{S, T}}) where {S, T} = FieldWrapper{S, T}
+parent_type(::Type{RingElemWrapper{S, T}}) where {S, T} = RingWrapper{S, T}
+parent_type(::Type{FieldElemWrapper{S, T}}) where {S, T} = FieldWrapper{S, T}
 
 parent(a::RingElemWrapper{S, T}) where {S, T} = a.parent
 parent(a::FieldElemWrapper{S, T}) where {S, T} = a.parent

--- a/src/resolution/resolution.jl
+++ b/src/resolution/resolution.jl
@@ -16,8 +16,6 @@ end
 
 elem_type(::Type{ResolutionSet{T}}) where T <: AbstractAlgebra.RingElem = sresolution{T}
 
-elem_type(::ResolutionSet{T}) where T <: AbstractAlgebra.RingElem = sresolution{T}
-
 parent_type(::Type{sresolution{T}}) where T <: AbstractAlgebra.RingElem = ResolutionSet{T}
 
 function checkbounds(r::sresolution, i::Int)


### PR DESCRIPTION
As they already exist via https://github.com/Nemocas/AbstractAlgebra.jl/blob/9dd22199b5262f23ad071b877f5d4fb5ce9ad436/src/fundamental_interface.jl#L53 and are only inconsistently used throughout Singular.jl.