### PR TITLE
Bump to 0.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Singular"
 uuid = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
-version = "0.20.0"
+version = "0.21.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"


### PR DESCRIPTION
We already bumped Nemo and AA to the next breaking versions, but did not make a Singular.jl release.