### PR TITLE
Avoid warnings about CMake compatibility

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.01)
+cmake_minimum_required(VERSION 3.5)
 
 project(libsingular_julia)
 


### PR DESCRIPTION
The full message I got is this:

> CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
>   Compatibility with CMake < 3.5 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.
