### PR TITLE
CI: always test treehash mismatch handling code path

### DIFF
--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -39,3 +39,18 @@ jobs:
             src_hash = bytes2hex(Pkg.GitTools.tree_hash(joinpath("deps", "src")))
             jll_hash == src_hash || error("tree hash is $src_hash, but JLL uses $jll_hash")
             '
+      # next force a treehash mismatch and verify that Singular runs in this
+      # setup; as a side effect this also reduce code coverage fluctuation when
+      # updating libsingular_julia_jll
+      - name: "Force treehash mismatch"
+        run: |
+          touch deps/src/FORCE_TREEHASH_MISMATCH
+      - name: "Run tests"
+        uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
+      - name: "Process code coverage"
+        uses: julia-actions/julia-processcoverage@v1
+      - name: "Upload coverage data to Codecov"
+        continue-on-error: true
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
On the one hand, this helps ensure it doesn't get broken. On the other
hand it avoids or at least reduces code coverage fluctuations that
happen when we switch from a situation with a treehash mismatch (which
thus tests that code path) to one without a treehash mismatch (which
does not test it) when updating libsingular_julia_jll.
