### PR TITLE
Adapt to `number_of_*` renaming

### DIFF
--- a/docs/src/ideal.md
+++ b/docs/src/ideal.md
@@ -78,7 +78,7 @@ Singular ideal over Singular polynomial ring (ZZ),(x,y),(dp(2),C) with generator
 ### Basic manipulation
 
 ```@docs
-ngens(::sideal)
+number_of_generators(::sideal)
 ```
 
 ```@docs
@@ -129,7 +129,7 @@ julia> R, (x, y) = polynomial_ring(ZZ, ["x", "y"])
 julia> I = Ideal(R, x^2 + 1, x*y)
 Singular ideal over Singular polynomial ring (ZZ),(x,y),(dp(2),C) with generators (x^2 + 1, x*y)
 
-julia> n = ngens(I)
+julia> n = number_of_generators(I)
 2
 
 julia> p = I[1]

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -44,7 +44,7 @@ The following parts of the Matrix interface from AbstractAlgebra are also implem
   * construction: `identity_matrix`, `identity_matrix`
   * arithmetic operations: `+`, `-`, `*`
   * comparison: `==`
-  * manipulation: `nrows`, `ncols`, `getindex`, `setindex!`, `transpose`, `iszero`
+  * manipulation: `number_of_rows`, `number_of_columns`, `getindex`, `setindex!`, `transpose`, `iszero`
 
 **Examples**
 
@@ -69,10 +69,10 @@ julia> M = identity_matrix(R, 4)
 0, 0, 1, 0
 0, 0, 0, 1]
 
-julia> nrows(M)
+julia> number_of_rows(M)
 4
 
-julia> ncols(M)
+julia> number_of_columns(M)
 4
 
 julia> iszero(M)

--- a/docs/src/module.md
+++ b/docs/src/module.md
@@ -85,7 +85,7 @@ x^2*gen(1)+x*gen(3)+2*x*gen(2)+3*y*gen(2)+gen(1)
 ### Basic manipulation
 
 ```@docs
-ngens(::smodule)
+number_of_generators(::smodule)
 ```
 
 ```@docs
@@ -129,7 +129,7 @@ true
 julia> n = rank(M)
 3
 
-julia> d = ngens(M)
+julia> d = number_of_generators(M)
 2
 ```
 

--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -43,7 +43,7 @@ import Random: rand
 using RandomExtensions: RandomExtensions, make, Make2
 
 import AbstractAlgebra: AbstractAlgebra, diagonal_matrix, factor,
-                        identity_matrix, kernel, ncols, ngens, nrows, order,
+                        identity_matrix, kernel, number_of_columns, ncols, number_of_generators, ngens, number_of_rows, nrows, order,
                         preimage, zero_matrix, expressify
 
 import AbstractAlgebra: pretty, Lowercase, LowercaseOff, Indent, Dedent
@@ -59,7 +59,7 @@ import Nemo: add!, addeq!, base_ring, canonical_unit,
              is_gen, is_monomial, inflate, is_negative, isone,
              is_term, is_unit, iszero, lift, leading_coefficient,
              leading_term, leading_monomial, monomials,
-             MPolyBuildCtx, mul!, nvars, ordering, parent_type,
+             MPolyBuildCtx, mul!, number_of_variables, nvars, ordering, parent_type,
              parent, primpart, promote_rule, push_term!,
              reconstruct, remove, sort_terms!,
              symbols, tail, terms, total_degree, trailing_coefficient, valuation,

--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -1,7 +1,7 @@
 export sideal, IdealSet, syz, lead, normalize!, is_constant, is_zerodim, fglm,
        fres, dimension, highcorner, jet, kbase, minimal_generating_set,
        independent_sets, maximal_independent_set, mres, mres_with_map,
-       ngens, nres, sres,
+       number_of_generators, ngens, nres, sres,
        intersection, homogenize_ideal, homogenize_ideal_with_weights,
        quotient, reduce, eliminate, kernel, equal, contains, is_var_generated,
        saturation, saturation2, satstd, slimgb, std, vdim, interreduce, degree, mult,
@@ -24,11 +24,11 @@ elem_type(::Type{IdealSet{spoly{T}}}) where T <: Nemo.RingElem = sideal{spoly{T}
 parent_type(::Type{sideal{spoly{T}}}) where T <: Nemo.RingElem = IdealSet{spoly{T}}
 
 @doc raw"""
-    ngens(I::sideal)
+    number_of_generators(I::sideal)
 
 Return the number of generators in the internal representation of the ideal $I$.
 """
-function ngens(I::sideal)
+function number_of_generators(I::sideal)
    GC.@preserve I return Int(libSingular.ngens(I.ptr))
 end
 

--- a/src/matrix/bigintmat.jl
+++ b/src/matrix/bigintmat.jl
@@ -10,11 +10,11 @@ function sbigintmat(r::Int, c::Int)
    return sbigintmat(libSingular.bigintmat_init(r, c))
 end
 
-function ncols(m::sbigintmat)
+function number_of_columns(m::sbigintmat)
    return Int(libSingular.bigintmat_ncols(m.ptr))
 end
 
-function nrows(m::sbigintmat)
+function number_of_rows(m::sbigintmat)
    return Int(libSingular.bigintmat_nrows(m.ptr))
 end
 

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -1,4 +1,4 @@
-export identity_matrix, matrix_space, nrows, ncols, smatrix, zero_matrix
+export identity_matrix, matrix_space, number_of_rows, nrows, number_of_columns, ncols, smatrix, zero_matrix
 
 ###############################################################################
 #
@@ -6,9 +6,9 @@ export identity_matrix, matrix_space, nrows, ncols, smatrix, zero_matrix
 #
 ###############################################################################
 
-nrows(M::smatrix) = Int(libSingular.nrows(M.ptr))
+number_of_rows(M::smatrix) = Int(libSingular.nrows(M.ptr))
 
-ncols(M::smatrix) = Int(libSingular.ncols(M.ptr))
+number_of_columns(M::smatrix) = Int(libSingular.ncols(M.ptr))
 
 function parent(M::smatrix{T}) where T <: AbstractAlgebra.RingElem
    return matrix_space{T}(M.base_ring, nrows(M), ncols(M))

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -20,12 +20,12 @@ parent_type(::Type{smodule{T}}) where T <: AbstractAlgebra.RingElem = ModuleClas
 
 
 @doc raw"""
-    ngens(I::smodule)
+    number_of_generators(I::smodule)
 
 Return the number of generators in the current representation of the module (as a list
 of vectors).
 """
-ngens(I::smodule) = I.ptr == C_NULL ? 0 : Int(libSingular.ngens(I.ptr))
+number_of_generators(I::smodule) = I.ptr == C_NULL ? 0 : Int(libSingular.ngens(I.ptr))
 
 @doc raw"""
     rank(I::smodule)

--- a/src/module/vector.jl
+++ b/src/module/vector.jl
@@ -41,7 +41,7 @@ function gen(M::FreeMod{T}, i::Int) where T <: AbstractAlgebra.RingElem
    return svector{T}(R, M.rank, libSingular.getindex(ptr, Cint(i - 1)))
 end
 
-ngens(M::FreeMod{T}) where T <: AbstractAlgebra.RingElem = rank(M)
+number_of_generators(M::FreeMod{T}) where T <: AbstractAlgebra.RingElem = rank(M)
 
 function deepcopy_internal(p::svector{T}, dict::IdDict) where T <: AbstractAlgebra.RingElem
    R = base_ring(p)

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -10,7 +10,7 @@ export spoly, PolyRing, change_base_ring, coeff, coefficients,
        leading_coefficient, leading_exponent_vector, leading_term,
        leading_monomial, lead_exponent,
        monomials, MPolyBuildCtx,
-       nvars, order, ordering, ordering_as_symbol, ordering_size, ordering_weights,
+       number_of_variables, nvars, order, ordering, ordering_as_symbol, ordering_size, ordering_weights,
        @polynomial_ring, primpart, push_term!,
        remove, sort_terms!, symbols,
        tail, terms, total_degree, trailing_coefficient,
@@ -73,7 +73,7 @@ function characteristic(R::PolyRingUnion)
    GC.@preserve R return Int(libSingular.rChar(R.ptr))
 end
 
-function nvars(R::PolyRingUnion)
+function number_of_variables(R::PolyRingUnion)
    return length(R.S)
 end
 


### PR DESCRIPTION
See https://github.com/Nemocas/AbstractAlgebra.jl/pull/1553. This should only be merged after https://github.com/oscar-system/Oscar.jl/pull/3231 is done to not make it harder to deliver bugfixes to OSCAR.