### PR TITLE
Provide a stale_age to mkpidlock

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -112,7 +112,7 @@ function build_code(src_hash)
    gmp_prefix = jll_artifact_dir(Singular_jll.GMP_jll)
    singular_prefix = jll_artifact_dir(Singular_jll)
 
-   Pidfile.mkpidlock("$installdir.lock") do
+   Pidfile.mkpidlock("$installdir.lock"; stale_age=60) do
       # delete any previous build or install artifacts
       rm(builddir; force=true, recursive=true)
       rm(installdir; force=true, recursive=true)


### PR DESCRIPTION
Normally the pidlock should be held for just a few seconds;
waiting for its age to exceed 60 seconds until we consider it stale
should be very safe. In fact Julia waits 5 times longer if the
process creating the pid lock file seems to be still running.

On the other hand, without a stale age, the lock file is *never*
considered stale, even if the process creating it definitely is gone,
and so the user can get stuck, which obviously is very bad. To
get unstuck they need to manually delete the lock file.
