### PR TITLE
Run tests jobs daily at 3:00AM UTC

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
       - 'release-*'
     tags: '*'
   pull_request:
+  schedule:
+    # Every day at 3:00 AM UTC (Tutorial tests initiated at 2:00AM)
+    - cron: '0 3 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    # Every day at 3:00 AM UTC (Tutorial tests initiated at 2:00AM)
+    - cron: '0 3 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
This PR adds cronjobs to run the CI and the OSCAR-CI once daily (at 3:00AM).

Provided that this runs, I am certain that @aaruni96 could enable slack notifications about failures at some point. (Or remind me how it works.)

cc @fingolfin @hannes14 

