### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Dependabot is like CompatHelper for GitHub actions. It creates PRs and bumps the versions of GitHub actions you are using. This reduces the maintenance burden, as you no longer have to develop PRs like https://github.com/oscar-system/Oscar.jl/pull/3902 manually.