### PR TITLE
CI: add workaround for new gcc with julia 1.6 on github runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,13 +48,13 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-      - name: "workaround libstdc++ issue for julia 1.6"
-         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
-         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
+      - name: "workaround libstdc++ issue for julia 1.6"
+         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,9 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - name: "workaround libstdc++ issue for julia 1.6"
+         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
       - name: "Build package"

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -78,6 +78,9 @@ jobs:
           julia --project=oscar-dev -e "using Pkg;
                                         Pkg.develop(PackageSpec(path=\".\"));
                                         Pkg.instantiate();"
+      - name: "workaround libstdc++ issue for julia 1.6"
+         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: fetch OscarDevTools
         if: github.repository != 'oscar-system/OscarDevTools.jl'
         run: |

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -78,9 +78,6 @@ jobs:
           julia --project=oscar-dev -e "using Pkg;
                                         Pkg.develop(PackageSpec(path=\".\"));
                                         Pkg.instantiate();"
-      - name: "workaround libstdc++ issue for julia 1.6"
-         if: matrix.julia-version == '1.6' && runner.os == 'Linux'
-         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: fetch OscarDevTools
         if: github.repository != 'oscar-system/OscarDevTools.jl'
         run: |


### PR DESCRIPTION
copied frm Oscar: 43bf5e00d39aa9c3d908df0b12a880fb85df3da5