### PR TITLE
Add workaround for GLIBCXX issue with julia 1.6

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -69,6 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Julia"
+        id: setup-julia
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -101,6 +102,9 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         run: |
           echo '${{ env.oscar_run_tests }}'


### PR DESCRIPTION
Same as https://github.com/Nemocas/Nemo.jl/pull/2088/.
This should fix the OscarCI tests.