### PR TITLE
Use `Base.pkgversion` to query the Singular.jl version

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -23,7 +23,6 @@ end
 
 import AbstractAlgebra
 using Nemo
-using Pkg
 using lib4ti2_jll
 using Singular_jll
 
@@ -186,9 +185,7 @@ FB Mathematik der Universitaet, D-67653 Kaiserslautern      \\
    end
 end
 
-pkgproject(m::Core.Module) = Pkg.Operations.read_project(Pkg.Types.projectfile_path(pkgdir(m)))
-pkgversion(m::Core.Module) = pkgproject(m).version
-const VERSION_NUMBER = pkgversion(@__MODULE__)
+const VERSION_NUMBER = Base.pkgversion(@__MODULE__)
 
 
 ###############################################################################


### PR DESCRIPTION
This needs at least julia 1.9, so may only be merged once https://github.com/oscar-system/Singular.jl/pull/875 is merged.