### PR TITLE
Bump julia compat to 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6'
           - '1.10'
           - '1.11'
           - '1.12-nightly'
@@ -53,9 +52,6 @@ jobs:
         uses: julia-actions/cache@v2
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
-      - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '1.6' # && runner.os == 'Linux'
-        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -102,9 +102,6 @@ jobs:
                                            varname=\"oscar_run_doctests\",
                                            filename=\"${GITHUB_ENV}\");"
 
-      - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '~1.6.0-0' # && runner.os == 'Linux'
-        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Run tests"
         run: |
           echo '${{ env.oscar_run_tests }}'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Singular"
 uuid = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
-version = "0.25.7"
+version = "0.26.0-DEV"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
@@ -31,6 +31,6 @@ Random = "1.6"
 RandomExtensions = "0.4.2"
 Singular_jll = "~404.100.107"
 Statistics = "1.6"
-julia = "1.6"
+julia = "1.10"
 lib4ti2_jll = "1.6.10"
 libsingular_julia_jll = "=0.47.5"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ The features of Singular so far include:
 
 ## Installation
 
-To use Singular.jl we require Julia 1.6 or higher. Please see
+To use Singular.jl we require Julia 1.10 or higher. Please see
 <https://julialang.org/downloads/> for instructions on
 how to obtain julia for your system.
 

--- a/src/number/n_unknown.jl
+++ b/src/number/n_unknown.jl
@@ -537,11 +537,6 @@ CoefficientRingID = Dict{Nemo.Ring, Any}()
 # To keep it type stable, we use a @generated function to treat being mutable
 # as a property available at compile time.
 
-if VERSION < v"1.7"
-  # This function was added in >= 1.7
-  ismutabletype(::Type{T}) where {T} = T.mutable
-end
-
 @generated function mutable_field_or_ring_type_wrapper(::Type{T}, ::Type{U}) where {T <: Nemo.Ring, U}
   if ismutabletype(T) && ismutabletype(U)
     S = T


### PR DESCRIPTION
This gets a breaking label as we wanna release this in a minor release. This makes it possible to still backport things to julia 1.6 with the 0.25.x release series.