### PR TITLE
Add `base_ring_type` methods, improve type stability

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -46,7 +46,7 @@ import AbstractAlgebra: AbstractAlgebra, Ideal, diagonal_matrix, factor,
 
 import AbstractAlgebra: pretty, Lowercase, LowercaseOff, Indent, Dedent, terse, is_terse
 
-import Nemo: add!, base_ring, canonical_unit,
+import Nemo: add!, base_ring, base_ring_type, canonical_unit,
              change_base_ring, characteristic, check_parent, codomain,
              coeff, coefficients, compose, constant_coefficient,
              contains, content, crt,
@@ -63,7 +63,7 @@ import Nemo: add!, base_ring, canonical_unit,
              symbols, tail, terms, total_degree, trailing_coefficient, valuation,
              var_index, vars, zero!, residue_ring
 
-export base_ring, elem_type, parent_type, parent
+export base_ring_type, base_ring, elem_type, parent_type, parent
 
 export residue_ring, polynomial_ring, WeylAlgebra, Ideal,
        MaximalIdeal, FreeModule, @polynomial_ring, @WeylAlgebra

--- a/src/caller.jl
+++ b/src/caller.jl
@@ -185,7 +185,7 @@ function create_ring_from_singular_ring(r::libSingular.ring_ptr)
       F = N_FField(iszero(p) ? QQ : N_ZpField(p), S)
       # now create the extension
       minpoly = F(libSingular.algExt_GetMinpoly(c, F.ptr))
-      basering = N_AlgExtField{typeof(base_ring(F))}(libSingular.nCopyCoeff(c), minpoly)
+      basering = N_AlgExtField{base_ring_type(F)}(libSingular.nCopyCoeff(c), minpoly)
    elseif libSingular.nCoeff_is_Nemo_Field(c) || libSingular.nCoeff_is_Nemo_Ring(c)
       cf = libSingular.nCopyCoeff(c)
       data_ptr = libSingular.nGetCoeffData(cf)

--- a/src/ideal/IdealTypes.jl
+++ b/src/ideal/IdealTypes.jl
@@ -4,12 +4,12 @@
 #
 ###############################################################################
 
-const IdealSetID = Dict{PolyRing, Set}()
+const IdealSetID = Dict{PolyRingUnion, Set}()
 
 mutable struct IdealSet{T <: AbstractAlgebra.NCRingElem} <: Set
    base_ring::PolyRingUnion
 
-   function IdealSet{T}(R::PolyRing) where T
+   function IdealSet{T}(R::PolyRingUnion) where T
       return get!(IdealSetID, R) do
          new(R)
       end::IdealSet{T}

--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -17,15 +17,17 @@ export sideal, IdealSet, syz, lead, normalize!, is_constant, is_zerodim, fglm,
 #
 ###############################################################################
 
-parent(a::sideal{T}) where {T <: Nemo.RingElem} = IdealSet{T}(a.base_ring)
+parent(a::sideal{T}) where T = IdealSet{T}(base_ring(a))
+parent_type(::Type{sideal{T}}) where T = IdealSet{T}
 
-base_ring(S::IdealSet) = S.base_ring
+base_ring(S::IdealSet) = S.base_ring::base_ring_type(S)
+base_ring_type(::Type{IdealSet{T}}) where T = parent_type(T)
 
-base_ring(I::sideal) = I.base_ring
+base_ring(I::sideal) = I.base_ring::base_ring_type(I)
+base_ring_type(::Type{sideal{T}}) where T = parent_type(T)
 
 elem_type(::Type{IdealSet{spoly{T}}}) where T <: Nemo.RingElem = sideal{spoly{T}}
 
-parent_type(::Type{sideal{spoly{T}}}) where T <: Nemo.RingElem = IdealSet{spoly{T}}
 
 @doc raw"""
     number_of_generators(I::sideal)

--- a/src/matrix/matrix.jl
+++ b/src/matrix/matrix.jl
@@ -14,9 +14,11 @@ function parent(M::smatrix{T}) where T <: AbstractAlgebra.RingElem
    return matrix_space{T}(M.base_ring, nrows(M), ncols(M))
 end
 
-base_ring(S::matrix_space) = S.base_ring
+base_ring(S::matrix_space) = S.base_ring::base_ring_type(S)
+base_ring_type(a::matrix_space{T}) where T = parent_type(T)
 
-base_ring(M::smatrix) = M.base_ring
+base_ring(M::smatrix) = M.base_ring::base_ring_type(M)
+base_ring_type(a::smatrix{T}) where T = parent_type(T)
 
 elem_type(::Type{matrix_space{T}}) where T <: AbstractAlgebra.RingElem = smatrix{T}
 

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -9,14 +9,15 @@ export jet, minimal_generating_set, ModuleClass, rank, smodule, slimgb,
 ###############################################################################
 
 parent(a::smodule{T}) where T <: Nemo.NCRingElem = ModuleClass{T}(a.base_ring)
+parent_type(::Type{smodule{T}}) where T <: Nemo.NCRingElem = ModuleClass{T}
 
-base_ring(S::ModuleClass) = S.base_ring
+base_ring(S::ModuleClass) = S.base_ring::base_ring_type(S)
+base_ring_type(::Type{ModuleClass{T}}) where T = parent_type(T)
 
-base_ring(I::smodule) = I.base_ring
+base_ring(I::smodule) = I.base_ring::base_ring_type(I)
+base_ring_type(::Type{smodule{T}}) where T = parent_type(T)
 
 elem_type(::Type{ModuleClass{T}}) where T <: Nemo.NCRingElem = smodule{T}
-
-parent_type(::Type{smodule{T}}) where T <: Nemo.NCRingElem = ModuleClass{T}
 
 
 @doc raw"""

--- a/src/module/vector.jl
+++ b/src/module/vector.jl
@@ -7,14 +7,15 @@ export FreeMod, svector, gens, rank, vector, jet
 ###############################################################################
 
 parent(v::svector{T}) where {T <: Nemo.NCRingElem} = FreeMod{T}(v.base_ring, v.rank)
+parent_type(::Type{svector{T}}) where {T <: Nemo.NCRingElem} = FreeMod{T}
 
-base_ring(R::FreeMod) = R.base_ring
+base_ring(R::FreeMod) = R.base_ring::base_ring_type(R)
+base_ring_type(a::Type{FreeMod{T}}) where {T <: Nemo.NCRingElem} = parent_type(T)
 
-base_ring(v::svector) = v.base_ring
+base_ring(v::svector) = v.base_ring::base_ring_type(v)
+base_ring_type(a::Type{svector{T}}) where {T <: Nemo.NCRingElem} = parent_type(T)
 
 elem_type(::Type{FreeMod{T}}) where {T <: Nemo.NCRingElem} = svector{T}
-
-parent_type(::Type{svector{T}}) where {T <: Nemo.NCRingElem} = FreeMod{T}
 
 @doc raw"""
     rank(M::FreeMod)

--- a/src/number/n_GF.jl
+++ b/src/number/n_GF.jl
@@ -9,12 +9,9 @@ export n_GF, N_GField
 elem_type(::Type{N_GField}) = n_GF
 
 parent(a::n_GF) = a.parent
-
 parent_type(::Type{n_GF}) = N_GField
 
-base_ring(a::n_GF) = Union{}
-
-base_ring(a::N_GField) = Union{}
+base_ring_type(::Type{N_GField}) = Union{}
 
 function characteristic(R::N_GField)
    return ZZ(_characteristic(R))

--- a/src/number/n_Q.jl
+++ b/src/number/n_Q.jl
@@ -10,12 +10,10 @@ export n_Q, Rationals, reconstruct, isone, iszero, is_unit, divexact,
 elem_type(::Type{Rationals}) = n_Q
 
 parent(a::n_Q) = QQ
-
 parent_type(::Type{n_Q}) = Rationals
 
-base_ring(a::n_Q) = ZZ
-
 base_ring(a::Rationals) = ZZ
+base_ring_type(::Type{Rationals}) = Integers
 
 characteristic(R::Rationals) = ZZ(0)
 

--- a/src/number/n_Z.jl
+++ b/src/number/n_Z.jl
@@ -9,12 +9,9 @@ export n_Z, Integers, crt
 elem_type(::Type{Integers}) = n_Z
 
 parent(a::n_Z) = ZZ
-
 parent_type(::Type{n_Z}) = Integers
 
-base_ring(a::n_Z) = Union{}
-
-base_ring(a::Integers) = Union{}
+base_ring_type(::Type{Integers}) = Union{}
 
 characteristic(R::Integers) = ZZ(0)
 

--- a/src/number/n_Zn.jl
+++ b/src/number/n_Zn.jl
@@ -9,12 +9,10 @@ export n_Zn, N_ZnRing, characteristic
 elem_type(::Type{N_ZnRing}) = n_Zn
 
 parent(a::n_Zn) = a.parent
-
 parent_type(::Type{n_Zn}) = N_ZnRing
 
-base_ring(a::n_Zn) = ZZ
-
 base_ring(a::N_ZnRing) = ZZ
+base_ring_type(::Type{N_ZnRing}) = Integers
 
 function characteristic(R::N_ZnRing)
    return ZZ(libSingular.n_GetChar(R.ptr))

--- a/src/number/n_Zp.jl
+++ b/src/number/n_Zp.jl
@@ -9,12 +9,9 @@ export n_Zp, N_ZpField
 elem_type(::Type{N_ZpField}) = n_Zp
 
 parent(a::n_Zp) = a.parent
-
 parent_type(::Type{n_Zp}) = N_ZpField
 
-base_ring(a::n_Zp) = Union{}
-
-base_ring(a::N_ZpField) = Union{}
+base_ring_type(::Type{N_ZpField}) = Union{}
 
 function characteristic(R::N_ZpField)
    return ZZ(libSingular.n_GetChar(R.ptr))

--- a/src/number/n_algExt.jl
+++ b/src/number/n_algExt.jl
@@ -11,9 +11,8 @@ elem_type(::Type{N_AlgExtField{T}}) where {T <: Field} = n_algExt{T}
 parent(a::n_algExt) = a.parent
 parent_type(::Type{n_algExt{T}}) where {T <: Field} = N_AlgExtField{T}
 
-base_ring(a::n_algExt) = base_ring(parent(a))
-
-base_ring(a::N_AlgExtField) = base_ring(a.minpoly)
+base_ring(a::N_AlgExtField) = base_ring(a.minpoly)::base_ring_type(a)
+base_ring_type(::Type{N_AlgExtField{T}}) where {T <: Field} = T
 
 @doc raw"""
     gen(F::N_AlgExtField)

--- a/src/number/n_transExt.jl
+++ b/src/number/n_transExt.jl
@@ -10,12 +10,10 @@ export n_transExt, N_FField, transcendence_degree, transcendence_basis,
 elem_type(::Type{N_FField{T}}) where {T <: Field} = n_transExt{T}
 
 parent(a::n_transExt) = a.parent
-
 parent_type(::Type{n_transExt{T}}) where {T <: Field} = N_FField{T}
 
-base_ring(a::n_transExt) = base_ring(parent(a))
-
-base_ring(a::N_FField) = a.base_ring
+base_ring(a::N_FField) = a.base_ring::base_ring_type(a)
+base_ring_type(::Type{N_FField{T}}) where {T <: Field} = T
 
 @doc raw"""
     transcendence_degree(F::N_FField)

--- a/src/number/n_unknown.jl
+++ b/src/number/n_unknown.jl
@@ -6,14 +6,13 @@
 elem_type(::Type{N_Ring{T}}) where T <: Nemo.RingElem = n_RingElem{T}
 elem_type(::Type{N_Field{T}}) where T <: Nemo.FieldElem = n_FieldElem{T}
 
-parent_type(::Type{n_RingElem{T}}) where T <: Nemo.RingElem = N_Ring{T}
-parent_type(::Type{n_FieldElem{T}}) where T <: Nemo.RingElem = N_Field{T}
-
 parent(a::n_unknown) = a.parent
+parent_type(::Type{n_RingElem{T}}) where T <: Nemo.RingElem = N_Ring{T}
+parent_type(::Type{n_FieldElem{T}}) where T <: Nemo.FieldElem = N_Field{T}
 
-base_ring(R::N_unknown) = R.base_ring
-
-base_ring(a::n_unknown) = base_ring(parent(a))
+base_ring(R::N_unknown) = R.base_ring::base_ring_type(R)
+base_ring_type(::Type{N_Ring{T}}) where T = parent_type(T)
+base_ring_type(::Type{N_Field{T}}) where T = parent_type(T)
 
 function check_parent(a::n_unknown, b::n_unknown)
    parent(a) != parent(b) && error("Incompatible parents")

--- a/src/poly/lp.jl
+++ b/src/poly/lp.jl
@@ -51,15 +51,14 @@ AbstractAlgebra.@enable_all_show_via_expressify slpalg
 #
 ###############################################################################
 
-parent(p::slpalg) = p.parent
-
-base_ring(R::LPRing{T}) where T <: Nemo.RingElem = R.base_ring::parent_type(T)
-
-base_ring(p::slpalg) = base_ring(parent(p))
-
 elem_type(::Type{LPRing{T}}) where T <: Nemo.RingElem = slpalg{T}
 
+parent(p::slpalg) = p.parent
 parent_type(::Type{slpalg{T}}) where T <: Nemo.RingElem = LPRing{T}
+
+base_ring(R::LPRing{T}) where T <: Nemo.RingElem = R.base_ring::base_ring_type(R)
+base_ring_type(::Type{LPRing{T}}) where T <: Nemo.RingElem = parent_type(T)
+
 
 @doc raw"""
     degree_bound(R::LPRing)

--- a/src/poly/plural.jl
+++ b/src/poly/plural.jl
@@ -6,9 +6,8 @@ export spluralg, PluralRing, GAlgebra
 #
 ###############################################################################
 
-base_ring(R::PluralRing{T}) where T <: Nemo.RingElem = R.base_ring
-
-base_ring(p::spluralg) = base_ring(parent(p))
+base_ring(R::PluralRing{T}) where T <: Nemo.RingElem = R.base_ring::base_ring_type(R)
+base_ring_type(::Type{PluralRing{T}}) where T <: Nemo.RingElem = parent_type(T)
 
 elem_type(::Type{PluralRing{T}}) where T <: Nemo.RingElem = spluralg{T}
 

--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -29,14 +29,12 @@ export ordering_lp, ordering_ip, ordering_dp, ordering_Dp, ordering_wp, ordering
 ###############################################################################
 
 parent(p::SPolyUnion) = p.parent
+parent_type(::Type{spoly{T}}) where T <: Nemo.RingElem = PolyRing{T}
 
-base_ring(R::PolyRing{T}) where T <: Nemo.RingElem = R.base_ring::parent_type(T)
-
-base_ring(p::spoly) = base_ring(parent(p))
+base_ring(R::PolyRing) = R.base_ring::base_ring_type(R)
+base_ring_type(::Type{PolyRing{T}}) where T <: Nemo.RingElem = parent_type(T)
 
 elem_type(::Type{PolyRing{T}}) where T <: Nemo.RingElem = spoly{T}
-
-parent_type(::Type{spoly{T}}) where T <: Nemo.RingElem = PolyRing{T}
 
 @doc raw"""
     has_global_ordering(R::PolyRingUnion)

--- a/src/resolution/resolution.jl
+++ b/src/resolution/resolution.jl
@@ -6,17 +6,16 @@ export Resolution, ResolutionSet, sresolution, betti, minres
 #
 ###############################################################################
 
-base_ring(r::sresolution) = r.base_ring
+base_ring(r::sresolution) = r.base_ring::base_ring_type(r)
+base_ring_type(a::Type{sresolution{T}}) where {T <: Nemo.NCRingElem} = parent_type(T)
 
-base_ring(R::ResolutionSet) = R.base_ring
+base_ring(R::ResolutionSet) = R.base_ring::base_ring_type(R)
+base_ring_type(a::Type{ResolutionSet{T}}) where {T <: Nemo.NCRingElem} = parent_type(T)
 
-function parent(r::sresolution{T}) where T <: AbstractAlgebra.RingElem
-   return ResolutionSet{T}(r.base_ring)
-end
+parent(r::sresolution{T}) where T = ResolutionSet{T}(r.base_ring)
+parent_type(::Type{sresolution{T}}) where T <: AbstractAlgebra.RingElem = ResolutionSet{T}
 
 elem_type(::Type{ResolutionSet{T}}) where T <: AbstractAlgebra.RingElem = sresolution{T}
-
-parent_type(::Type{sresolution{T}}) where T <: AbstractAlgebra.RingElem = ResolutionSet{T}
 
 function checkbounds(r::sresolution, i::Int)
    # structure has 1 more item than the mathematical length

--- a/test/ideal/sideal-test.jl
+++ b/test/ideal/sideal-test.jl
@@ -533,14 +533,14 @@ end
 
    I = Ideal(R, x^2*y + 2y + 1, y^2 + 1)
 
-   F = syz(I) #TODO @inferred broken
+   F = @inferred syz(I)
 
    M = @inferred Singular.Matrix(I)
    N = @inferred Singular.Matrix(F)
 
    # check they are actually syzygies
    @test iszero(M*N)
-   F = syz_slimgb(I) #TODO @inferred broken
+   F = @inferred syz_slimgb(I)
 
    N = @inferred Singular.Matrix(F)
 

--- a/test/module/smodule-test.jl
+++ b/test/module/smodule-test.jl
@@ -158,13 +158,13 @@ end
 
    M = Singular.Module(R, v1, v2)
 
-   Z = syz(M)
+   Z = @inferred syz(M)
 
    @test ngens(Z) == 1
 
    @test Z[1] == vector(R, x, -y)
 
-   Z = syz_slimgb(M)
+   Z = @inferred syz_slimgb(M)
 
    @test ngens(Z) == 1
 

--- a/test/number-test.jl
+++ b/test/number-test.jl
@@ -8,17 +8,21 @@ testrings = [
       ]
 
 
-@testset "number.parent and type relations for $(elemT)" for (elemT, ringT, parentRing, R) in testrings
+@testset "number.parent and type relations for $(elemT)" for (elemT, ringT, expected_base_ring, R) in testrings
    @test elem_type(R) == elemT
    @test elem_type(ringT) == elemT
    @test parent_type(elemT) == ringT
-   @test base_ring(R) == parentRing
+   if expected_base_ring === Union{}
+     @test base_ring_type(R) === Union{}
+   else
+     @test base_ring(R) == expected_base_ring
+     @test base_ring(R) isa base_ring_type(R)
+   end
    @test R isa ringT
 end
 
-@testset "number.integer_constructors for $(elemT)" for (elemT, ringT, parentRing, R) in testrings
+@testset "number.integer_constructors for $(elemT)" for (elemT, ringT, expected_base_ring, R) in testrings
    a = R()
-   @test base_ring(a) == parentRing
    @test parent(a) == R
    @test a isa elemT
 
@@ -44,7 +48,7 @@ end
 end
 
 # test adhoc arithmetic resp. arithmetic via promotion_rules
-@testset "number.adhoc_binary for $(elemT)" for (elemT, ringT, parentRing, R) in testrings
+@testset "number.adhoc_binary for $(elemT)" for (elemT, ringT, expected_base_ring, R) in testrings
    @testset "number.adhoc_binary for $(elemT) and $T" for T in (Int8, UInt8, Int, BigInt, Nemo.ZZ, ZZ)
 
       a = R(2)

--- a/test/poly/plural-test.jl
+++ b/test/poly/plural-test.jl
@@ -189,3 +189,20 @@ end
    @test nvars(S) == 2
 end
 
+@testset "plural.ideal" begin
+   r, (x, y) = polynomial_ring(QQ, ["x", "y"], ordering = :degrevlex)
+   R, (x, y) = GAlgebra(r, Singular.Matrix(r, [1 1; 0 1]),
+                           Singular.Matrix(r, [0 x; 0 0]))
+
+   S = Singular.create_ring_from_singular_ring(Singular.libSingular.rCopy(R.ptr))
+
+   # zero ideal
+   I = Ideal(S)
+   @test base_ring(I) isa base_ring_type(I)
+   @test parent(I) isa parent_type(I)
+
+   # principal ideal
+   I = Ideal(S, gen(S,1))
+   @test base_ring(I) isa base_ring_type(I)
+   @test parent(I) isa parent_type(I)
+end


### PR DESCRIPTION
Also ensures ideas over non-commmutative rings also have a parent.

Contains PR #896