### PR TITLE
Run Oscar testing on RPTU runners

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-oscar:
     needs: generatematrix
-    name: ${{ join(matrix.*.name) }} - ${{ matrix.os }}, julia ${{ matrix.julia-version}}
+    name: ${{ join(matrix.*.name) }} - ${{ join(matrix.os) }}, julia ${{ matrix.julia-version}}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     env:

--- a/OscarCI.toml
+++ b/OscarCI.toml
@@ -1,6 +1,7 @@
 title = "metadata for oscar CI run"
 
 [env]
+os = [["Linux","RPTU","normal-memory"]]
 # os = [ "ubuntu-latest" ]
 # julia-version = [ "~1.6.0-0" ]
 # branches = [ "<matching>", "release" ]


### PR DESCRIPTION
This change should result in the Oscar tests running on RPTU runners (and then finishes faster).