### PR TITLE
Restrict various type params to concrete types

### DIFF
--- a/src/matrix/MatrixTypes.jl
+++ b/src/matrix/MatrixTypes.jl
@@ -12,6 +12,7 @@ mutable struct matrix_space{T <: Nemo.RingElem} <: Set
    ncols::Int
 
    function matrix_space{T}(R::PolyRing, r::Int, c::Int) where T
+      @assert isconcretetype(T)
       return get!(MatrixSpaceID, (R, r, c)) do
          new{T}(R, r, c)
       end::matrix_space{T}
@@ -24,6 +25,7 @@ mutable struct smatrix{T <: Nemo.RingElem} <: Nemo.SetElem
 
    # take ownership of the pointer - not for general users
    function smatrix{T}(R::PolyRing, ptr::libSingular.matrix_ptr) where {T}
+      @assert isconcretetype(T)
       T === elem_type(R) || error("type mismatch")
       z = new(ptr, R)
       finalizer(_smatrix_clear_fn, z)

--- a/src/module/ModuleTypes.jl
+++ b/src/module/ModuleTypes.jl
@@ -11,6 +11,7 @@ mutable struct FreeMod{T <: Nemo.NCRingElem} <: Module{T}
    rank::Int
 
    function FreeMod{T}(R::Nemo.NCRing, r::Int) where T
+      @assert isconcretetype(T)
       return get!(FreeModID, (R, r)) do
          new(R, r)
       end::FreeMod{T}

--- a/src/number/NumberTypes.jl
+++ b/src/number/NumberTypes.jl
@@ -419,6 +419,7 @@ mutable struct N_Ring{T <: Nemo.RingElem} <: Ring
    base_ring::Nemo.Ring
 
    function N_Ring{T}(R::Nemo.Ring, cached::Bool=true) where T
+      @assert isconcretetype(T)
       return AbstractAlgebra.get_cached!(CoeffRingID, R, cached) do
          c = libSingular.register(R)
          GC.@preserve R begin
@@ -442,6 +443,7 @@ mutable struct N_Field{T <: Nemo.FieldElem} <: Field
    base_ring::Nemo.Field
 
    function N_Field{T}(R::Nemo.Field, cached::Bool=true) where T
+      @assert isconcretetype(T)
       return AbstractAlgebra.get_cached!(CoeffFieldID, R, cached) do
          c = libSingular.register(R)
          GC.@preserve R begin

--- a/src/poly/LPTypes.jl
+++ b/src/poly/LPTypes.jl
@@ -20,6 +20,7 @@ mutable struct LPRing{T <: Nemo.RingElem} <: AbstractAlgebra.NCRing
    # take ownership of the pointer - not for general users
    function LPRing{T}(r::libSingular.ring_ptr, R, deg_bound::Int,
                           s::Vector{Symbol}=singular_symbols(r)) where T
+      @assert isconcretetype(T)
       @assert deg_bound > 0
       @assert r.cpp_object != C_NULL
       ord = Cint[]

--- a/src/poly/PluralTypes.jl
+++ b/src/poly/PluralTypes.jl
@@ -16,6 +16,7 @@ mutable struct PluralRing{T <: Nemo.RingElem} <: AbstractAlgebra.NCRing
 
    # take ownership of the pointer - not for general users
    function PluralRing{T}(r::libSingular.ring_ptr, R, s::Vector{Symbol}=singular_symbols(r)) where T <: Nemo.RingElem
+      @assert isconcretetype(T)
       @assert r.cpp_object != C_NULL
       ord = Cint[]
       libSingular.rOrdering_helper(ord, r)

--- a/src/poly/PolyTypes.jl
+++ b/src/poly/PolyTypes.jl
@@ -18,6 +18,7 @@ mutable struct PolyRing{T <: Nemo.RingElem} <: Nemo.MPolyRing{T}
 
    # take ownership of the ring ptr
    function PolyRing{T}(r::libSingular.ring_ptr, R, s::Vector{Symbol}=singular_symbols(r)) where T
+      @assert isconcretetype(T)
       @assert r.cpp_object != C_NULL
       ord = Cint[]
       libSingular.rOrdering_helper(ord, r)

--- a/src/resolution/ResolutionTypes.jl
+++ b/src/resolution/ResolutionTypes.jl
@@ -10,6 +10,7 @@ mutable struct ResolutionSet{T <: Nemo.RingElem} <: Set
    base_ring::PolyRing
 
    function ResolutionSet{T}(R::PolyRing) where T
+      @assert isconcretetype(T)
       return get!(ResolutionSetID, R) do
          new(R)
       end
@@ -27,6 +28,7 @@ mutable struct sresolution{T <: Nemo.RingElem} <: Nemo.SetElem
    function sresolution{T}(R::PolyRing, ptr::libSingular.syStrategy_ptr,
                            minimal::Bool=false,
                            index_1_is_an_ideal::Bool=false) where T
+      @assert isconcretetype(T)
       T === elem_type(R) || error("type mismatch")
       R.refcount += 1
       z = new(R, ptr, minimal, index_1_is_an_ideal)


### PR DESCRIPTION
This should always be the case, but in the past it sometimes
was violated due to bugs. So better to enforce it, at least
for the time being.
