### PR TITLE
Add global type assertion for QQ and ZZ

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -110,6 +110,9 @@ import .libSingular: call_interpreter
 
 include("Number.jl")
 
+global ZZ::Integers
+global QQ::Rationals
+
 include("poly/OrderingTypes.jl")
 
 include("poly/PolyTypes.jl")


### PR DESCRIPTION
This requires moving the `__init__` method until after `Integers`
and `Rationals` are defined, so I simply moved it to the end of
the file.

Fixes genuine type instability, and silence the warnings reported by

    using Singular, JET;  Qt,t = QQ[:t]; @report_opt t+t
