### PR TITLE
CI: Add testing against Singular's `spielwiese` branch

### DIFF
--- a/.github/workflows/singular.yml
+++ b/.github/workflows/singular.yml
@@ -49,7 +49,7 @@ jobs:
         id: setup-julia
         with:
           version: ${{ matrix.julia-version }}
-      - name: Checkout Singular
+      - name: "Checkout Singular"
         uses: actions/checkout@v6
         with:
           repository: 'Singular/Singular'


### PR DESCRIPTION
This is basically just copied from GAP.jl and slightly adapted. Makes heavy use of https://github.com/oscar-system/Singular.jl/pull/924.

cc @ederc @jankoboehm 