### PR TITLE
etc: fix override script for macos

### DIFF
--- a/etc/run_with_override.jl
+++ b/etc/run_with_override.jl
@@ -58,9 +58,17 @@ libsingular_src_marker = joinpath(
 )
 write(libsingular_src_marker, "force recompilation marker\n")
 
+singular_libdir = joinpath(singularoverride, "lib")
+dyld_fallback = let existing = get(ENV, "DYLD_FALLBACK_LIBRARY_PATH", "")
+    isempty(existing) ? singular_libdir : existing * ":" * singular_libdir
+end
+
 # prepend our temporary depot to the depot list...
 try
-    withenv("JULIA_DEPOT_PATH"=>tmpdepot*":"*join(DEPOT_PATH, ":")) do
+    withenv(
+        "JULIA_DEPOT_PATH"=>tmpdepot*":"*join(DEPOT_PATH, ":"),
+        "DYLD_FALLBACK_LIBRARY_PATH"=>dyld_fallback,
+    ) do
 
         # ... and start Julia, by default with the same project environment
         run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(ARGS)`)


### PR DESCRIPTION
Alternative to https://github.com/oscar-system/Singular.jl/pull/929.
Two changes:

- add a temporary file into the libsingular_julia sources when overriding Singular, to force recompilation of libsingular_julia
- but since CxxWrap will complain about the libsingular_julia.dylib missing even before the recompilation (on macos), we patch a DYLD_FALLBACK_LIBRARY_PATH