### PR TITLE
Allow `spoly` coercion between compatible `PolyRings`

### DIFF
--- a/src/poly/poly.jl
+++ b/src/poly/poly.jl
@@ -1542,7 +1542,7 @@ function (R::PolyRing{T})(n::T) where T <: n_unknown
    return spoly{T}(R, n)
 end
 
-function (R::PolyRing)(f::T) where T <: Nemo.MPolyRingElem
+function (R::PolyRing)(f::Union{spoly, T}) where T <: Nemo.MPolyRingElem
   parent(f) == R && return f
   B = base_ring(R)
   g = MPolyBuildCtx(R)
@@ -1554,11 +1554,6 @@ end
 
 function (R::PolyRing{S})(n::T) where {S <: Nemo.RingElem, T <: Nemo.RingElem}
    return spoly{S}(R, base_ring(R)(n))
-end
-
-function (R::PolyRing)(p::spoly)
-   parent(p) != R && error("Unable to coerce polynomial")
-   return p
 end
 
 ###############################################################################

--- a/test/matrix/smatrix-test.jl
+++ b/test/matrix/smatrix-test.jl
@@ -45,7 +45,7 @@
    Rx, _ = polynomial_ring(QQ, ["x"])
    Z = zero_matrix(Rx, 2, 3)
    @test_throws ArgumentError S(Z)
-   @test_throws Exception S(Z[1, 1])
+   @test S(Z[1, 1]) isa smatrix
 end
 
 @testset "smatrix.manipulation" begin

--- a/test/poly/poly-test.jl
+++ b/test/poly/poly-test.jl
@@ -238,7 +238,7 @@ end
     R, (x,y) = polynomial_ring(QQ, ["x", "y"])
     Q, (a,b) = QuotientRing(R, Ideal(R, x-y))
     @test iszero(a-b)
-    @test (a-b) == Q(0)
+    @test (a-b) == Q(0) == Q(x-y)
     @test a == b
 end
 
@@ -468,6 +468,24 @@ end
    f = x^2+y^3+z^5
 
    @test S(f) == a^2+b^3+c^5
+end
+
+@testset "poly.coerce_spoly_between_PolyRings" begin
+   R, (x, y) = polynomial_ring(ZZ, ["x", "y"])
+   S, (a, b) = polynomial_ring(QQ, ["x", "y"])
+
+   f = x^2 + 3*x*y + y^2
+   g = S(f)
+
+   @test g == a^2 + 3*a*b + b^2
+   @test parent(g) == S
+
+   @test S(g) === g
+   @test S(zero(R)) == zero(S)
+   @test S(R(5)) == S(5)
+
+   T, (u,) = polynomial_ring(QQ, ["u"])
+   @test_throws ErrorException T(f)
 end
 
 @testset "poly.test_spoly_differential" begin


### PR DESCRIPTION
The `(R::PolyRing)(p::spoly)` method previously only accepted polynomials already belonging to `R`, raising an error on anything else. This PR merges it with the `MPolyRingElem` coercion method so that `spoly` from a compatible ring (e.g. `R` into `R/I`) is rebuilt term-by-term in the target ring, falling back to an error if the rings are incompatible.

```
using Singular
R, (x, y, z) = polynomial_ring(QQ, ["x", "y", "z"])
f = (x+y)^2
S, _ = QuotientRing(R, std(Ideal(R, x^3 - y, z^2 - x)))
S(f)  # previously errored, now works
```