### PR TITLE
Set isGB for leading module

### DIFF
--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -124,6 +124,7 @@ function lead(M::smodule)
    R = base_ring(M)
    ptr = GC.@preserve M R libSingular.id_Head(M.ptr, R.ptr)
    z = Module(R, ptr)
+   z.isGB = true
    return z
 end
 

--- a/test/module/smodule-test.jl
+++ b/test/module/smodule-test.jl
@@ -96,6 +96,7 @@ end
 
    m = Singular.Module(R, v, vector(R, R(0), R(0), 2+x))
    n = lead(m)
+   @test n.isGB == true
    @test n[1] == vector(R, 2*x^10, R(0), R(0))
    @test n[2] == vector(R, R(0), R(0), R(2))
 end


### PR DESCRIPTION
While working on a pull request for Oscar  [(#5915)](https://github.com/oscar-system/Oscar.jl/pull/5915) I encountered, that `lead` for modules does not set the attribute `isGB` to `true`, preventing me from using some functions which check `isGB`.
Instead of setting the attribute downstream in Oscar manually, this PR sets it directly in the function `lead`.