### PR TITLE
Sparse transformation matrix for lift_std

### DIFF
--- a/src/ideal/ideal.jl
+++ b/src/ideal/ideal.jl
@@ -1048,7 +1048,7 @@ end
 @doc raw"""
     lift_std_syz(M::sideal{S}; complete_reduction::Bool = false) where S <: spoly
 
-Computes the Groebner base G of I, the transformation matrix T and the syzygies of M.
+Computes the Groebner basis G of I, the transformation matrix T and the syzygies of M.
 Returns G,T,S
 (Matrix(G) = Matrix(I) * T, 0=Matrix(M)*Matrix(S))
 """
@@ -1061,13 +1061,24 @@ end
 @doc raw"""
     lift_std(M::sideal{S}; complete_reduction::Bool = false) where S <: spoly
 
-Computes the Groebner base G of M and the transformation matrix T such that
+Computes the Groebner basis G of M and the transformation matrix T such that
 (Matrix(G) = Matrix(M) * T)
 """
 function lift_std(M::sideal{S}; complete_reduction::Bool = false) where S <: spoly
    R = base_ring(M)
    ptr,T_ptr = GC.@preserve M R libSingular.id_LiftStd(M.ptr, R.ptr, complete_reduction)
    return sideal{S}(R, ptr), smatrix{S}(R, T_ptr)
+end
+
+@doc raw"""
+    lift_std(M::sideal{S}; complete_reduction::Bool = false) where S <: spoly
+
+Computes the Groebner basis G of M and the transformation matrix T in sparse format.
+"""
+function lift_std_sparse_transformation_matrix(M::sideal{S}; complete_reduction::Bool = false) where S <: spoly
+   R = base_ring(M)
+   ptr,T_ptr = GC.@preserve M R libSingular.id_LiftStd(M.ptr, R.ptr, complete_reduction)
+   return sideal{S}(R, ptr), Module(smatrix{S}(R, T_ptr))
 end
 
 ###############################################################################

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -1,5 +1,6 @@
 export jet, minimal_generating_set, ModuleClass, rank, smodule, slimgb,
-       eliminate, modulo, lift, dimension, division, divrem, prune, prune_with_map,
+       eliminate, modulo, lift, lift_std, lift_std_sparse_transformation_matrix,
+       dimension, division, divrem, prune, prune_with_map,
        prune_with_map_projection, quotient, contains, saturation, saturation2
 
 ###############################################################################
@@ -651,6 +652,12 @@ function lift_std(M::smodule; complete_reduction::Bool = false)
    R = base_ring(M)
    ptr,T_ptr = GC.@preserve M R libSingular.id_LiftStd(M.ptr, R.ptr, complete_reduction)
    return Module(R, ptr), smatrix{elem_type(R)}(R, T_ptr)
+end
+
+function lift_std_sparse_transformation_matrix(M::smodule; complete_reduction::Bool = false)
+   R = base_ring(M)
+   ptr,T_ptr = GC.@preserve M R libSingular.id_LiftStd(M.ptr, R.ptr, complete_reduction)
+   return Module(R, ptr), Module(smatrix{elem_type(R)}(R, T_ptr))
 end
 
 ###############################################################################

--- a/src/module/module.jl
+++ b/src/module/module.jl
@@ -633,7 +633,7 @@ end
 @doc raw"""
     lift_std_syz(M::smodule)
 
-Computes the Groebner base `G` of `M`, the transformation matrix `T` and the syzygies of M.
+Computes the Groebner basis `G` of `M`, the transformation matrix `T` and the syzygies of M.
 Returns a tuple `(G,T,S)` satisfying `(Matrix(G) = Matrix(M) * T, 0=Matrix(M)*Matrix(S))`.
 """
 function lift_std_syz(M::smodule; complete_reduction::Bool = false)
@@ -645,7 +645,7 @@ end
 @doc raw"""
     lift_std(M::smodule)
 
-Computes the Groebner base `G` of `M` and the transformation matrix `T` such that
+Computes the Groebner basis `G` of `M` and the transformation matrix `T` such that
 `(Matrix(G) = Matrix(M) * T)`.
 """
 function lift_std(M::smodule; complete_reduction::Bool = false)
@@ -654,6 +654,12 @@ function lift_std(M::smodule; complete_reduction::Bool = false)
    return Module(R, ptr), smatrix{elem_type(R)}(R, T_ptr)
 end
 
+
+@doc raw"""
+    lift_std_sparse_transformation_matrix(M::smodule)
+
+Computes the Groebner basis `G` of `M` and the transformation matrix`T` in sparse format.
+"""
 function lift_std_sparse_transformation_matrix(M::smodule; complete_reduction::Bool = false)
    R = base_ring(M)
    ptr,T_ptr = GC.@preserve M R libSingular.id_LiftStd(M.ptr, R.ptr, complete_reduction)

--- a/test/ideal/sideal-test.jl
+++ b/test/ideal/sideal-test.jl
@@ -672,6 +672,12 @@ end
    @test T[2,1] == 1
    @test T[1,2] == 1
 
+   G, T = @inferred Singular.lift_std_sparse_transformation_matrix(I)
+   @test G[1] == y
+   @test G[2] == x
+   @test T[1] == vector(R, R(0), R(1))
+   @test T[2] == vector(R, R(1), R(0))
+
    G, T = @inferred Singular.lift_std(I, complete_reduction = true)
    @test G[1] == y
    @test G[2] == x

--- a/test/module/smodule-test.jl
+++ b/test/module/smodule-test.jl
@@ -149,6 +149,16 @@ end =#
    G2 = std(M)
 
    @test G2.isGB == true
+
+   G, m = lift_std_sparse_transformation_matrix(M)
+
+   sm = Singular.Module(R,
+                        vector(R,-x,-y,R(1)),
+                        vector(R,R(1),R(0),R(0)),
+                        vector(R,R(0),R(1),R(0)))
+   @test m[1] == sm[1]
+   @test m[2] == sm[2]
+   @test m[3] == sm[3]
 end
 
 @testset "smodule.syz" begin


### PR DESCRIPTION
This PR adds a variant `lift_std_sparse_transformation_matrix` for ideals and modules.

This should help to fix https://github.com/oscar-system/Oscar.jl/issues/4925: In OSCAR one should be able to call something like

```
R, ... = polynomial_ring(...)
M = ...
G,m = Singular.lift_std_sparse_transformation_matrix(M)
sm = sparse_matrix(R, m)
```

@HechtiDerLachs Would this make you happy?