### PR TITLE
Revert "Add global type assertion for QQ and ZZ (#918)"

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -110,9 +110,6 @@ import .libSingular: call_interpreter
 
 include("Number.jl")
 
-global ZZ::Integers
-global QQ::Rationals
-
 include("poly/OrderingTypes.jl")
 
 include("poly/PolyTypes.jl")


### PR DESCRIPTION
I think #918 broke Oscar, but we did not notice since downstream tests were not running. But they are running now and retriggering the downstream tests for #918 fail: https://github.com/oscar-system/Singular.jl/actions/runs/25220629873. If my theory is correct, tests should pass with this PR here.
