### PR TITLE
Reapply "Add global type assertion for QQ and ZZ (#918)"

### DIFF
--- a/src/Singular.jl
+++ b/src/Singular.jl
@@ -110,6 +110,9 @@ import .libSingular: call_interpreter
 
 include("Number.jl")
 
+global ZZ::Integers
+global QQ::Rationals
+
 include("poly/OrderingTypes.jl")
 
 include("poly/PolyTypes.jl")


### PR DESCRIPTION
This was originally PR #918. We reverted it in #951 as it was/is breaking the Oscar test suite, which is very puzzling, and may hint at a deeper problem.