### PR TITLE
Track C++ coverage for bundled libsingular build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v6
         with:
+          gcov_include: deps/src
           token: ${{ secrets.CODECOV_TOKEN }}
 
   docs:

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   treehash:
     runs-on: ubuntu-latest
+    env:
+      SINGULAR_JL_ENABLE_CPP_COVERAGE: "1"
     steps:
       - uses: actions/checkout@v6
       - name: "Set up Julia"
@@ -54,3 +56,5 @@ jobs:
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
         uses: codecov/codecov-action@v6
+        with:
+          gcov_include: deps/src

--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -14,6 +14,17 @@ message(STATUS "Found JlCxx at ${JlCxx_location}")
 include(CheckCXXCompilerFlag)
 
 set(CMAKE_CXX_STANDARD 14)
+option(SINGULAR_JL_ENABLE_CPP_COVERAGE
+  "Build libsingular_julia with native coverage instrumentation" OFF)
+
+if(SINGULAR_JL_ENABLE_CPP_COVERAGE)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    add_compile_options(--coverage)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+  else()
+    message(FATAL_ERROR "Native coverage is only supported with GCC- or Clang-like compilers")
+  endif()
+endif()
 
 # avoid gcc 9 internal compiler error,
 # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90998

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -71,6 +71,13 @@ function jll_artifact_dir(the_jll::Module)
     return the_jll.find_artifact_dir()
 end
 
+function cmake_extra_args(env::AbstractDict{String, String}=ENV)
+   if get(env, "SINGULAR_JL_ENABLE_CPP_COVERAGE", "") == "1"
+      return ["-DSINGULAR_JL_ENABLE_CPP_COVERAGE=ON"]
+   end
+   return String[]
+end
+
 function build_code(src_hash)
    @info "Bundled C++ sources don't match libsingular_julia_jll"
 
@@ -111,6 +118,7 @@ function build_code(src_hash)
 
    gmp_prefix = jll_artifact_dir(Singular_jll.GMP_jll)
    singular_prefix = jll_artifact_dir(Singular_jll)
+   extra_args = cmake_extra_args()
 
    Pidfile.mkpidlock("$installdir.lock"; stale_age=60) do
       # delete any previous build or install artifacts
@@ -125,6 +133,7 @@ function build_code(src_hash)
              -DSingular_PREFIX=$(singular_prefix)
              -DCMAKE_INSTALL_PREFIX=$(installdir)
              -DCMAKE_BUILD_TYPE=Release
+             $(extra_args)
              -S $srcdir
              -B $builddir
             `)


### PR DESCRIPTION
Add an environment-controlled CMake coverage mode for bundled libsingular_julia builds, and cover the Julia-to-CMake wiring with a focused setup test.

Enable native coverage upload in the existing treehash workflow and teach the main Codecov upload step to include deps/src gcov data.

Co-authored-by: Codex <codex@openai.com>

Resolves #224