### PR TITLE
Touch the schedule in `CI.yml`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,8 +8,8 @@ on:
     tags: '*'
   pull_request:
   schedule:
-    # Every day at 3:00 AM UTC (Tutorial tests initiated at 2:00AM)
-    - cron: '0 3 * * *'
+    # Every day at 3:01 AM UTC (Tutorial tests initiated at 2:00AM)
+    - cron: '1 3 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
This should fix the failing scheduled CI job that complains that Hans hasn't verified his email address for too long.

If @fingolfin merges this right now, this CI job should then be connected to his github account.