### PR TITLE
Test for closure boxes in CI

### DIFF
--- a/test/ClosureBoxes.jl
+++ b/test/ClosureBoxes.jl
@@ -1,0 +1,12 @@
+# Captured variables that are reassigned force Julia to allocate a `Core.Box`,
+# which defeats type inference. `Test.detect_closure_boxes` exists since
+# Julia 1.14.
+if isdefined(Test, :detect_closure_boxes)
+  @testset "Closure boxes" begin
+    boxes = Test.detect_closure_boxes(Singular)
+    for (m, vars) in boxes
+      println("Boxed variable(s) ", join(vars, ", "), " in ", m)
+    end
+    @test length(boxes) == 0
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ import Singular.Nemo
 using Test
 
 include("Aqua.jl")
+include("ClosureBoxes.jl")
 
 include("number-test.jl")
 include("poly-test.jl")


### PR DESCRIPTION
Julia 1.14 adds `Test.detect_closure_boxes` (JuliaLang/julia#60478), which lists methods whose lowered code allocates `Core.Box`. A box appears when a closure captures a variable that is assigned more than once and defeats type inference for that variable.

Running it on Singular (including submodules such as `libSingular`) finds nothing, so this PR only adds the check to keep it that way. Same approach as Nemocas/AbstractAlgebra.jl#2498.

- New `test/ClosureBoxes.jl` runs the detector and requires zero hits.
- Skipped on Julia versions without the function, so only the `nightly` CI job covers it until 1.14 is released. That job has `continue-on-error: true`, so a regression shows as a warning rather than a failure for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
