### PR TITLE
Touch the schedule in `oscar.yml`

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - master
   schedule:
-    # Every day at 3:00 AM UTC (Tutorial tests initiated at 2:00AM)
-    - cron: '0 3 * * *'
+    # Every day at 3:02 AM UTC (Tutorial tests initiated at 2:00AM)
+    - cron: '2 3 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
The daily `oscar.yml` run fails at startup with "Please verify your email address to run GitHub Actions workflows", e.g. https://github.com/oscar-system/Singular.jl/actions/runs/34558128036 

For `schedule` events GitHub attributes the run to the user who last pushed a change to that workflow's cron schedule on the default branch (for a web-merged PR: the merger). For `oscar.yml` that is still #825 from 2024, merged by @hannes14 whose email address is no longer verified. Later edits to the file (dependabot bumps) do not reassign it -- only the `schedule:` block counts.

Changing the cron moves the attribution to whoever merges this, the same fix #962 applied to `CI.yml`. 3:02 keeps it clear of `CI.yml` at 3:01.

**Must be merged by an account with a verified email** for this to help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
